### PR TITLE
Don't bind mount docker.sock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+* Don't bind mount (the sometimes non-existent) docker.sock [Pablo]
 * Expose a RESIN_SUPERVISOR_VERSION env var to app [Pablo]
 
 # v1.1.1

--- a/src/application.coffee
+++ b/src/application.coffee
@@ -147,8 +147,6 @@ application.start = start = (app) ->
 		'/lib/firmware:/lib/firmware'
 		'/run/dbus:/run/dbus'
 		'/run/dbus:/host_run/dbus'
-		'/var/run/docker.sock:/run/docker.sock'
-		'/var/run/docker.sock:/host_run/docker.sock'
 		'/etc/resolv.conf:/etc/resolv.conf:rw'
 	]
 	Promise.try ->


### PR DESCRIPTION
It doesn't exist on devices that use rce - plus using the host docker/rce doesn't make sense, users should use docker-in-docker. Supervisor would delete any user-created images anyways.