### PR TITLE
Bugfix: assign app.containerId before attaching logger

### DIFF
--- a/src/application.coffee
+++ b/src/application.coffee
@@ -225,11 +225,11 @@ application.start = start = (app) ->
 					logSystemEvent(logTypes.startAppError, app, err)
 					throw err
 			.then ->
+				app.containerId = container.id
 				device.updateState(commit: app.commit)
 				logger.attach(app)
 		.tap (container) ->
 			# Update the app info, only if starting the container worked.
-			app.containerId = container.id
 			knex('app').update(app).where(appId: app.appId)
 			.then (affectedRows) ->
 				knex('app').insert(app) if affectedRows == 0


### PR DESCRIPTION
Otherwise the app is started but the logger can't find the container to attach to, resulting in an endless container creation loop.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/resin-io/resin-supervisor/40)
<!-- Reviewable:end -->
