### PR TITLE
Revert "Make config.json writes atomic"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,3 @@
-* Make config.json writes atomic [Pablo]
-
 # v1.3.2
 
 * Do not report the tun addresses to API [Praneeth]

--- a/src/bootstrap.coffee
+++ b/src/bootstrap.coffee
@@ -6,7 +6,6 @@ deviceRegister = require 'resin-register-device'
 { resinApi } = require './request'
 fs = Promise.promisifyAll(require('fs'))
 EventEmitter = require('events').EventEmitter
-execAsync = Promise.promisify(require('child_process').exec)
 config = require './config'
 configPath = '/boot/config.json'
 appsPath  = '/boot/apps.json'
@@ -49,7 +48,7 @@ bootstrap = ->
 		.then (device) ->
 			userConfig.registered_at = Date.now()
 			userConfig.deviceId = device.id
-			writeConfigFile(userConfig)
+			fs.writeFileAsync(configPath, JSON.stringify(userConfig))
 		.return(userConfig)
 	.then (userConfig) ->
 		console.log('Finishing bootstrapping')
@@ -67,14 +66,6 @@ bootstrap = ->
 		.tap ->
 			bootstrapper.doneBootstrapping()
 
-
-writeConfigFile = (config) ->
-	fs.writeFileAsync(configPath + '.new', JSON.stringify(config))
-	.then ->
-		fs.renameAsync(configPath + '.new', configPath)
-	.then ->
-		execAsync('sync')
-
 readConfigAndEnsureUUID = ->
 	# Load config file
 	fs.readFileAsync(configPath, 'utf8')
@@ -85,7 +76,7 @@ readConfigAndEnsureUUID = ->
 		deviceRegister.generateUUID()
 		.then (uuid) ->
 			userConfig.uuid = uuid
-			writeConfigFile(userConfig)
+			fs.writeFileAsync(configPath, JSON.stringify(userConfig))
 			.return(uuid)
 	.catch (err) ->
 		console.log('Error generating and saving UUID: ', err)


### PR DESCRIPTION
Reverts resin-io/resin-supervisor#64

config.json is bind mounted (the file, and not its directory), so this doesn't work and breaks provisioning. Need to think an alternative way of doing this.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/resin-io/resin-supervisor/70)
<!-- Reviewable:end -->
