### PR TITLE
Ignore all godeps workspace diffs

### DIFF
--- a/gosuper/Godeps/_workspace/.gitattributes
+++ b/gosuper/Godeps/_workspace/.gitattributes
@@ -1,0 +1,2 @@
+# Ignore all godeps workspace diffs
+* -diff


### PR DESCRIPTION
This will mean the godeps workspace files are treated as binary files and won't automatically show a diff

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/resin-io/resin-supervisor/71)
<!-- Reviewable:end -->
