### PR TITLE
BugFix - OOMAdjust wrongly runs on all PIDs without a name match

### DIFF
--- a/gosuper/psutils/psutils.go
+++ b/gosuper/psutils/psutils.go
@@ -35,7 +35,7 @@ func (procs *Procs) AdjustOOMPriorityByName(processName string, value int, ignor
 		// Find the process with the given name
 		if currProcess, err := process.NewProcess(pid); err != nil {
 			continue
-		} else if name, err := currProcess.Name(); err != nil && name != processName {
+		} else if name, err := currProcess.Name(); err != nil || name != processName {
 			continue
 		} else if err := procs.AdjustOOMPriority(int(pid), value, ignoreIfNonZero); err == nil {
 			found = true


### PR DESCRIPTION
Connects to #39

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/resin-io/resin-supervisor/81)
<!-- Reviewable:end -->
