### PR TITLE
Quickfix: use String .split instead of _.split when getting Host OS version

### DIFF
--- a/src/device.coffee
+++ b/src/device.coffee
@@ -181,10 +181,10 @@ exports.updateState = do ->
 exports.getOSVersion = ->
 	fs.readFileAsync(config.hostOsVersionPath)
 	.then (releaseData) ->
-		lines = _.split(releaseData, "\n")
+		lines = releaseData.split("\n")
 		releaseItems = {}
 		for line in lines
-			[ key, val ] = _.split(line, '=')
+			[ key, val ] = line.split('=')
 			releaseItems[_.trim(key)] = _.trim(val)
 		return releaseItems['PRETTY_NAME']
 	.catch (err) ->


### PR DESCRIPTION
lodash 3 doesn't have the _.split function :S

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/resin-io/resin-supervisor/89)
<!-- Reviewable:end -->
