### PR TITLE
Check for valid strings or ints in all config values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+* Check for valid strings or ints in all config values [Pablo]
 * Remove quotes in OS version [Pablo]
 
 # v1.5.0

--- a/src/config.coffee
+++ b/src/config.coffee
@@ -7,38 +7,39 @@ checkInt = (s) ->
 		return
 	return i
 
-checkValidKey = (s) ->
-	# Make sure `s` exists and is not an empty string, or 'null'.
-	if !s? or s == 'null' or s == ''
+checkString = (s) ->
+	# Make sure `s` exists and is not an empty string, or 'null' or 'undefined'.
+	# This might happen if the parsing of config.json on the host using jq is wrong (it is buggy in some versions).
+	if !s? or s == 'null' or s == 'undefined' or s == ''
 		return
 	return s
 
-dockerRoot = process.env.DOCKER_ROOT ? '/mnt/root/var/lib/rce'
+dockerRoot = checkString(process.env.DOCKER_ROOT) ? '/mnt/root/var/lib/rce'
 
 # Defaults needed for both gosuper and node supervisor are declared in entry.sh
 module.exports = config =
-	apiEndpoint: process.env.API_ENDPOINT ? 'https://api.resin.io'
-	listenPort: process.env.LISTEN_PORT ? 80
+	apiEndpoint: checkString(process.env.API_ENDPOINT) ? 'https://api.resin.io'
+	listenPort: checkInt(process.env.LISTEN_PORT) ? 80
 	gosuperAddress: "http://unix:#{process.env.GOSUPER_SOCKET}:"
-	deltaHost: process.env.DELTA_ENDPOINT ? 'https://delta.resin.io'
-	registryEndpoint: process.env.REGISTRY_ENDPOINT ? 'registry.resin.io'
+	deltaHost: checkString(process.env.DELTA_ENDPOINT) ? 'https://delta.resin.io'
+	registryEndpoint: checkString(process.env.REGISTRY_ENDPOINT) ? 'registry.resin.io'
 	pubnub:
-		subscribe_key: checkValidKey(process.env.PUBNUB_SUBSCRIBE_KEY) ? process.env.DEFAULT_PUBNUB_SUBSCRIBE_KEY
-		publish_key: checkValidKey(process.env.PUBNUB_PUBLISH_KEY) ? process.env.DEFAULT_PUBNUB_PUBLISH_KEY
-	mixpanelToken: checkValidKey(process.env.MIXPANEL_TOKEN) ? process.env.DEFAULT_MIXPANEL_TOKEN
+		subscribe_key: checkString(process.env.PUBNUB_SUBSCRIBE_KEY) ? process.env.DEFAULT_PUBNUB_SUBSCRIBE_KEY
+		publish_key: checkString(process.env.PUBNUB_PUBLISH_KEY) ? process.env.DEFAULT_PUBNUB_PUBLISH_KEY
+	mixpanelToken: checkString(process.env.MIXPANEL_TOKEN) ? process.env.DEFAULT_MIXPANEL_TOKEN
 	dockerSocket: process.env.DOCKER_SOCKET
-	supervisorImage: process.env.SUPERVISOR_IMAGE ? 'resin/rpi-supervisor'
-	configMountPoint: process.env.CONFIG_MOUNT_POINT ? '/mnt/mmcblk0p1/config.json'
-	ledFile: process.env.LED_FILE ? '/sys/class/leds/led0/brightness'
+	supervisorImage: checkString(process.env.SUPERVISOR_IMAGE) ? 'resin/rpi-supervisor'
+	configMountPoint: checkString(process.env.CONFIG_MOUNT_POINT) ? '/mnt/mmcblk0p1/config.json'
+	ledFile: checkString(process.env.LED_FILE) ? '/sys/class/leds/led0/brightness'
 	bootstrapRetryDelay: checkInt(process.env.BOOTSTRAP_RETRY_DELAY_MS) ? 30000
 	restartSuccessTimeout: checkInt(process.env.RESTART_SUCCESS_TIMEOUT) ? 60000
 	appUpdatePollInterval: checkInt(process.env.APPLICATION_UPDATE_POLL_INTERVAL) ? 60000
 	successMessage: 'SUPERVISOR OK'
 	forceSecret:
-		api: process.env.RESIN_SUPERVISOR_SECRET ? null
-		logsChannel: process.env.RESIN_SUPERVISOR_LOGS_CHANNEL ? null
-	vpnStatusPath: process.env.VPN_STATUS_PATH ? '/mnt/root/run/openvpn/vpn_status'
+		api: checkString(process.env.RESIN_SUPERVISOR_SECRET) ? null
+		logsChannel: checkString(process.env.RESIN_SUPERVISOR_LOGS_CHANNEL) ? null
+	vpnStatusPath: checkString(process.env.VPN_STATUS_PATH) ? '/mnt/root/run/openvpn/vpn_status'
 	checkInt: checkInt
-	hostOsVersionPath: process.env.HOST_OS_VERSION_PATH ? '/mnt/root/etc/os-release'
+	hostOsVersionPath: checkString(process.env.HOST_OS_VERSION_PATH) ? '/mnt/root/etc/os-release'
 	dockerRoot: dockerRoot
-	btrfsRoot: process.env.BTRFS_ROOT ? "#{dockerRoot}/btrfs/subvolumes"
+	btrfsRoot: checkString(process.env.BTRFS_ROOT) ? "#{dockerRoot}/btrfs/subvolumes"


### PR DESCRIPTION
connects to #91 

When the host OS passes us the config env vars, it does so after [using jq on config.json](https://github.com/resin-os/meta-resin/blob/master/meta-resin-common/recipes-support/resin-conf/resin-conf/resin-vars#L44-L56), so values that aren't present can appear as a string that says "null". We add some validation so that we correctly use the default values in this case.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/resin-io/resin-supervisor/94)
<!-- Reviewable:end -->
