### PR TITLE
Add resin-supervisor-host-socket.service for webterminal

### DIFF
--- a/tools/dind/Dockerfile
+++ b/tools/dind/Dockerfile
@@ -83,5 +83,6 @@ COPY config/services/ /etc/systemd/system/
 COPY resin-vars vpn-init /usr/src/app/
 
 RUN systemctl enable resin-supervisor-dind
+RUN systemctl enable resin-supervisor-host-socket
 
 CMD env > /etc/docker.env; exec /sbin/init

--- a/tools/dind/config/services/resin-supervisor-host-socket.service
+++ b/tools/dind/config/services/resin-supervisor-host-socket.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=Host socket for resin supervisor
+Requires=resin-supervisor.service
+After=resin-supervisor.service
+
+[Service]
+Restart=always
+ExecStartPre=-/bin/rm -f /resin-data/resin-supervisor/host
+ExecStart=/bin/bash -c ' \
+    while true; do \
+        rm -f /resin-data/resin-supervisor/host; \
+        socat UNIX-LISTEN:/resin-data/resin-supervisor/host EXEC:/bin/bash,pty,setsid,setpgid,stderr,ctty; \
+    done'
+ExecStopPost=-/bin/rm -f /resin-data/resin-supervisor/host
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Currently it's missing, so web terminal is not available in the development environment.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/resin-io/resin-supervisor/99)
<!-- Reviewable:end -->
