### PR TITLE
Host config improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+* Add RESIN_HOST_LOG_TO_DISPLAY variable [Pablo]
+* Add system logs for special actions and host config [Pablo]
+* Fix setting config.txt for RPi 3 [Pablo]
+* Fix saving config vars to DB before reboot [Pablo]
 * Bind mount host /var/lib/connman to application /host_var/lib/connman [Aleksis]
 * Add RESIN_SUPERVISOR_DELTA to special list so that app is not restarted when it changes [Pablo]
 

--- a/gosuper/gosuper/main.go
+++ b/gosuper/gosuper/main.go
@@ -25,6 +25,7 @@ func setupApi(router *mux.Router) {
 	apiv1.HandleFunc("/reboot", RebootHandler).Methods("POST")
 	apiv1.HandleFunc("/shutdown", ShutdownHandler).Methods("POST")
 	apiv1.HandleFunc("/vpncontrol", VPNControl).Methods("POST")
+	apiv1.HandleFunc("/set-log-to-display", LogToDisplayControl).Methods("POST")
 }
 
 func startApi(listenAddress string, router *mux.Router) {

--- a/src/application.coffee
+++ b/src/application.coffee
@@ -334,7 +334,7 @@ specialActionEnvVars =
 
 executedSpecialActionEnvVars = {}
 
-executeSpecialActionsAndBootConfig = (env) ->
+executeSpecialActionsAndHostConfig = (env) ->
 	Promise.try ->
 		_.map specialActionEnvVars, (specialActionCallback, key) ->
 			if env[key]? && specialActionCallback?
@@ -342,10 +342,10 @@ executeSpecialActionsAndBootConfig = (env) ->
 				if !_.has(executedSpecialActionEnvVars, key) or executedSpecialActionEnvVars[key] != env[key]
 					specialActionCallback(env[key])
 					executedSpecialActionEnvVars[key] = env[key]
-		bootConfigVars = _.pick env, (val, key) ->
-			return _.startsWith(key, device.bootConfigEnvVarPrefix)
-		if !_.isEmpty(bootConfigVars)
-			device.setBootConfig(bootConfigVars)
+		hostConfigVars = _.pick env, (val, key) ->
+			return _.startsWith(key, device.hostConfigEnvVarPrefix)
+		if !_.isEmpty(hostConfigVars)
+			device.setHostConfig(hostConfigVars)
 
 wrapAsError = (err) ->
 	return err if _.isError(err)
@@ -527,7 +527,7 @@ application.update = update = (force) ->
 				# Run special functions against variables if remoteAppEnvs has the corresponding variable function mapping.
 				Promise.map appsWithChangedEnvs, (appId) ->
 					Promise.using lockUpdates(remoteApps[appId], force), ->
-						executeSpecialActionsAndBootConfig(remoteAppEnvs[appId])
+						executeSpecialActionsAndHostConfig(remoteAppEnvs[appId])
 						.then ->
 							# If an env var shouldn't cause a restart but requires an action, we should still
 							# save the new env to the DB
@@ -613,7 +613,7 @@ application.initialize = ->
 	knex('app').select()
 	.then (apps) ->
 		Promise.map apps, (app) ->
-			executeSpecialActionsAndBootConfig(JSON.parse(app.env))
+			executeSpecialActionsAndHostConfig(JSON.parse(app.env))
 			.then ->
 				unlockAndStart(app)
 	.catch (error) ->

--- a/src/application.coffee
+++ b/src/application.coffee
@@ -496,7 +496,9 @@ formatLocalApps = (apps) ->
 	localAppEnvs = {}
 	localApps = _.mapValues apps, (app) ->
 		localAppEnvs[app.appId] = JSON.parse(app.env)
-		app.env = JSON.stringify(_.omit(localAppEnvs[app.appId], _.keys(specialActionEnvVars)))
+		app.env = _.omit localAppEnvs[app.appId], (v, k) ->
+			_.startsWith(k, device.hostConfigEnvVarPrefix)
+		app.env = JSON.stringify(_.omit(app.env, _.keys(specialActionEnvVars)))
 		app = _.pick(app, [ 'appId', 'commit', 'imageId', 'env' ])
 	return { localApps, localAppEnvs }
 

--- a/src/application.coffee
+++ b/src/application.coffee
@@ -472,7 +472,7 @@ getEnvAndFormatRemoteApps = (deviceId, remoteApps, uuid, apiKey) ->
 			utils.extendEnvVars(app.environment_variable, uuid)
 		.then (fullEnv) ->
 			env = _.omit(fullEnv, _.keys(specialActionEnvVars))
-			env = _.omitBy env, (v, k) ->
+			env = _.omit env, (v, k) ->
 				_.startsWith(k, device.hostConfigEnvVarPrefix)
 			return [
 				{

--- a/src/application.coffee
+++ b/src/application.coffee
@@ -68,6 +68,10 @@ logTypes =
 		eventName: 'Application update error'
 		humanName: 'Failed to update application'
 
+logSystemMessage = (message, obj, eventName) ->
+	logger.log({ message, isSystem: true })
+	utils.mixpanelTrack(eventName ? message, obj)
+
 logSystemEvent = (logType, app, error) ->
 	message = "#{logType.humanName} '#{app.imageId}'"
 	if error?
@@ -80,22 +84,15 @@ logSystemEvent = (logType, app, error) ->
 		if _.isEmpty(errMessage)
 			errMessage = 'Unknown cause'
 		message += " due to '#{errMessage}'"
-	logger.log({ message, isSystem: true })
-	utils.mixpanelTrack(logType.eventName, {app, error})
+	logSystemMessage(message, {app, error}, logType.eventName)
 	return
-
-logMessage = (msg) ->
-	logger.log(msg, isSystem: true)
-	utils.mixpanelTrack(msg)
 
 logSpecialAction = (action, value, success) ->
 	if success
 		msg = "Applied config variable #{action} = #{value}"
 	else
 		msg = "Applying config variable #{action} = #{value}"
-	logMessage(msg)
-
-
+	logSystemMessage(msg, {}, "Apply special action #{success ? "success" : "in progress"}")
 
 application = {}
 
@@ -360,7 +357,7 @@ executeSpecialActionsAndHostConfig = (env) ->
 		hostConfigVars = _.pick env, (val, key) ->
 			return _.startsWith(key, device.hostConfigEnvVarPrefix)
 		if !_.isEmpty(hostConfigVars)
-			device.setHostConfig(hostConfigVars, logMessage)
+			device.setHostConfig(hostConfigVars, logSystemMessage)
 
 wrapAsError = (err) ->
 	return err if _.isError(err)

--- a/src/device.coffee
+++ b/src/device.coffee
@@ -118,7 +118,7 @@ setBootConfig = (env, logMessage) ->
 				configFromApp[key] != configFromFS[key]
 			throw new Error('Nothing to change') if _.isEmpty(toBeChanged) and _.isEmpty(toBeAdded)
 
-			logMessage("Applying boot config: #{configFromApp}", {}, "Apply boot config in progress")
+			logMessage("Applying boot config: #{JSON.stringify(configFromApp)}", {}, "Apply boot config in progress")
 			# We add the keys to be added first so they are out of any filters
 			outputConfig = _.map toBeAdded, (key) -> "#{key}=#{configFromApp[key]}"
 			outputConfig = outputConfig.concat _.map configPositions, (key, index) ->
@@ -137,7 +137,7 @@ setBootConfig = (env, logMessage) ->
 			.then ->
 				execAsync('sync')
 			.then ->
-				logMessage("Applied boot config: #{configFromApp}", {}, "Apply boot config success")
+				logMessage("Applied boot config: #{JSON.stringify(configFromApp)}", {}, "Apply boot config success")
 				return true
 			.catch (err) ->
 				logMessage("Error setting boot config: #{err}", {error: err}, "Apply boot config error")

--- a/src/device.coffee
+++ b/src/device.coffee
@@ -84,7 +84,7 @@ setLogToDisplay = (env, logMessage) ->
 				return false
 			else
 				if body.Data == true
-					logMessage("#{enable ? "Enabled" : "Disabled"} logs to display")
+					logMessage("#{if enable then "Enabled" else "Disabled"} logs to display")
 				return body.Data
 		.catch (err) ->
 			logMessage("Error setting log to display: #{err}", {error: err}, "Set log to display error")


### PR DESCRIPTION
connects to #107 
connects to #108 
connects to #109 

Allows enabling/disabling tty-replacement.service on the host, which causes logs (e.g. "Check your resin dashboard") to be sent to a display connected to the device.
Fixes applying config.txt changes for RPi3.
Adds some logging when applying special actions and host config.
Ensures host config changes are saved to the local DB before rebooting, preventing reboot loops when there's config changes.

(still untested)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/resin-io/resin-supervisor/113)
<!-- Reviewable:end -->
