### PR TITLE
Bind mount /var/lib/connman to application containers.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+* Bind mount host /var/lib/connman to application /host_var/lib/connman [Aleksis]
 * Add RESIN_SUPERVISOR_DELTA to special list so that app is not restarted when it changes [Pablo]
 
 # v1.6.1

--- a/src/application.coffee
+++ b/src/application.coffee
@@ -156,15 +156,17 @@ application.start = start = (app) ->
 		'/lib/modules': {}
 		'/lib/firmware': {}
 		'/run/dbus': {}
-		'/host_var/lib/connman': {}
+		'/host/var/lib/connman': {}
+		'/host/run/dbus': {}
 	binds = [
 		'/resin-data/' + app.appId + ':/data'
 		'/lib/modules:/lib/modules'
 		'/lib/firmware:/lib/firmware'
 		'/run/dbus:/run/dbus'
 		'/run/dbus:/host_run/dbus'
+		'/run/dbus:/host/run/dbus'
 		'/etc/resolv.conf:/etc/resolv.conf:rw'
-		'/var/lib/connman:/host_var/lib/connman'
+		'/var/lib/connman:/host/var/lib/connman'
 	]
 	Promise.try ->
 		# Parse the env vars before trying to access them, that's because they have to be stringified for knex..

--- a/src/application.coffee
+++ b/src/application.coffee
@@ -156,6 +156,7 @@ application.start = start = (app) ->
 		'/lib/modules': {}
 		'/lib/firmware': {}
 		'/run/dbus': {}
+		'/host_var/lib/connman': {}
 	binds = [
 		'/resin-data/' + app.appId + ':/data'
 		'/lib/modules:/lib/modules'
@@ -163,6 +164,7 @@ application.start = start = (app) ->
 		'/run/dbus:/run/dbus'
 		'/run/dbus:/host_run/dbus'
 		'/etc/resolv.conf:/etc/resolv.conf:rw'
+		'/var/lib/connman:/host_var/lib/connman'
 	]
 	Promise.try ->
 		# Parse the env vars before trying to access them, that's because they have to be stringified for knex..


### PR DESCRIPTION
connects to #117

This allows application containers to interface with host connman.

Host /var/lib/connman is bind mounted to /host_var/lib/connman to avoid
collisions with connman installations inside the container.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/resin-io/resin-supervisor/116)
<!-- Reviewable:end -->