### PR TITLE
Container restart policy specification.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+* Add restart policies and change default to auto-restart [Aleksis]
+
 # v1.10.1
 
 * Switch to docker-delta library to use deltas v2 [petrosagg]

--- a/src/application.coffee
+++ b/src/application.coffee
@@ -228,11 +228,13 @@ application.start = start = (app) ->
 			if portList?
 				portList.forEach (port) ->
 					ports[port + '/tcp'] = [ HostPort: port ]
+			restartPolicy = createRestartPolicy({ name: env['RESIN_APP_RESTART_POLICY'], maximumRetryCount: env['RESIN_APP_RESTART_RETRIES'] })
 			container.startAsync(
 				Privileged: true
 				NetworkMode: 'host'
 				PortBindings: ports
 				Binds: binds
+				RestartPolicy: restartPolicy
 			)
 			.catch (err) ->
 				statusCode = '' + err.statusCode
@@ -260,6 +262,22 @@ application.start = start = (app) ->
 		logSystemEvent(logTypes.startAppSuccess, app)
 	.finally ->
 		device.updateState(status: 'Idle')
+
+validRestartPolicies = [ 'no', 'always', 'on-failure', 'unless-stopped' ]
+# Construct a restart policy based on its name and maximumRetryCount.
+# Both arguments are optional, and the default policy is "always".
+#
+# Throws exception if an invalid policy name is given.
+# Returns a RestartPolicy { Name, MaximumRetryCount } object
+createRestartPolicy = ({ name, maximumRetryCount }) ->
+	if not name?
+		name = 'always'
+	if not (name in validRestartPolicies)
+		throw new Error("Invalid restart policy: #{name}")
+	policy = { Name: name }
+	if name is 'on-failure' and maximumRetryCount?
+		policy.MaximumRetryCount = maximumRetryCount
+	return policy
 
 getEnvironment = do ->
 	envApiEndpoint = url.resolve(config.apiEndpoint, '/environment')


### PR DESCRIPTION
connects to #106 

Allow users to set container restart policy using environment variables.

RESIN_APP_RESTART_POLICY sets the name of the policy, and
if policy is "on-failure", optionally, RESIN_APP_RESTART_RETRIES
sets the maximum number of retries.

More information on docker docs:
https://docs.docker.com/engine/reference/run/#restart-policies-restart

One major change we introduce here is that the default policy is set
to always while we used to have the default "no".

We validate the arguments and pass retries parameter only for the case
of "on-failure" as specified in Docker API as of v1.19.
We could let docker handle the arguments directly, gaining
forwards-compatibility with any new features, but I opted
for an implementation that is as well-defined as possible.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/resin-io/resin-supervisor/120)
<!-- Reviewable:end -->
