### PR TITLE
Add intro align with current resin.io docs

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -4,7 +4,7 @@ The Resin Supervisor is resin.io's agent that runs on devices. Its main role is 
 
 The Supervisor itself has its own API, with means for user applications to communicate and execute some special actions that affect the host OS or the application itself. There are two main ways for the application to interact with the Supervisor: the update lockfile and the HTTP API.
 
-Only Supervisors after version 1.1.0 have all of this functionality. This corresponds to OS images downloaded after October 14th 2015.
+Only Supervisors after version 1.1.0 have this functionality, and some of the endpoints appeared in later versions (we've noted it down where this is the case).Supervisor version 1.1.0 corresponds to OS images downloaded after October 14th 2015.
 
 ## HTTP API reference
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,3 +1,11 @@
+# Interacting with the Resin Supervisor
+
+The Resin Supervisor is resin.io's agent that runs on devices. Its main role is to ensure your app is running, and keep communications with the Resin API server.
+
+The Supervisor itself has its own API, with means for user applications to communicate and execute some special actions that affect the host OS or the application itself. There are two main ways for the application to interact with the Supervisor: the update lockfile and the HTTP API.
+
+Only Supervisors after version 1.1.0 have all of this functionality. This corresponds to OS images downloaded after October 14th 2015.
+
 ## HTTP API reference
 
 The supervisor exposes an HTTP API on port 48484 (`RESIN_SUPERVISOR_PORT`).

--- a/docs/API.md
+++ b/docs/API.md
@@ -4,7 +4,7 @@ The Resin Supervisor is resin.io's agent that runs on devices. Its main role is 
 
 The Supervisor itself has its own API, with means for user applications to communicate and execute some special actions that affect the host OS or the application itself. There are two main ways for the application to interact with the Supervisor: the update lockfile and the HTTP API.
 
-Only Supervisors after version 1.1.0 have this functionality, and some of the endpoints appeared in later versions (we've noted it down where this is the case).Supervisor version 1.1.0 corresponds to OS images downloaded after October 14th 2015.
+Only Supervisors after version 1.1.0 have this functionality, and some of the endpoints appeared in later versions (we've noted it down where this is the case). Supervisor version 1.1.0 corresponds to OS images downloaded after October 14th 2015.
 
 ## HTTP API reference
 


### PR DESCRIPTION
Resin.io docs are pulling this file when ever they are updated to keep official docs site in sync. So need to add intro paragraph to give context.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/resin-io/resin-supervisor/122)
<!-- Reviewable:end -->