### PR TITLE
Increase delta request timeout to 15 minutes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+* Increase delta request timeout to 15 minutes [Pablo]
+
 # v1.8.0
 
 * Add endpoints to start, stop and get app [Pablo, Kostas]

--- a/src/docker-utils.coffee
+++ b/src/docker-utils.coffee
@@ -59,6 +59,7 @@ findSimilarImage = (repoTag) ->
 		return 'resin/scratch'
 
 DELTA_OUT_OF_SYNC_CODES = [23, 24]
+DELTA_REQUEST_TIMEOUT = 15 * 60 * 1000
 
 exports.rsyncImageWithProgress = (imgDest, onProgress, startFromEmpty = false) ->
 	Promise.try ->
@@ -67,7 +68,7 @@ exports.rsyncImageWithProgress = (imgDest, onProgress, startFromEmpty = false) -
 		findSimilarImage(imgDest)
 	.then (imgSrc) ->
 		rsyncDiff = new Promise (resolve, reject) ->
-			progress request.get("#{config.deltaHost}/api/v1/delta?src=#{imgSrc}&dest=#{imgDest}", timeout: 5 * 60 * 1000)
+			progress request.get("#{config.deltaHost}/api/v1/delta?src=#{imgSrc}&dest=#{imgDest}", timeout: DELTA_REQUEST_TIMEOUT)
 			.on 'progress', (progress) ->
 				onProgress(percentage: progress.percent)
 			.on 'end', ->


### PR DESCRIPTION
connects to #125 

15 minutes should be enough for the delta server to calculate most diffs, without being to large in case of a real failure, but we can discuss it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/resin-io/resin-supervisor/139)
<!-- Reviewable:end -->
