### PR TITLE
Correctly compare container image name on cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+* Correctly compare container image name on cleanup [Pablo]
 * Log useful supervisor info to stdout/stderr [Kostas]
 
 # v1.10.0

--- a/src/docker-utils.coffee
+++ b/src/docker-utils.coffee
@@ -200,13 +200,16 @@ do ->
 				docker.listContainersAsync(all: true)
 				.filter (containerInfo) ->
 					# Do not remove user apps.
-					if _.contains(appTags, containerInfo.Image)
-						return false
-					if _.contains(locallyCreatedTags, containerInfo.Image)
-						return false
-					if !_.contains(supervisorTags, containerInfo.Image)
-						return true
-					return containerHasExited(containerInfo.Id)
+					getRepoAndTag(containerInfo.Image)
+					.then ({ repo, tag }) ->
+						repoTag = buildRepoTag(repo, tag)
+						if _.contains(appTags, repoTag)
+							return false
+						if _.contains(locallyCreatedTags, repoTag)
+							return false
+						if !_.contains(supervisorTags, repoTag)
+							return true
+						return containerHasExited(containerInfo.Id)
 				.map (containerInfo) ->
 					docker.getContainer(containerInfo.Id).removeAsync()
 					.then ->


### PR DESCRIPTION
connects to #157 
Docker 1.10 sends containerInfo.Image without the ":latest", so
the image name doesn't match the app's imageId.
This fix first splits the image name into repo and tag and then rebuilds
it to include ":latest" when appropriate. Should avoid removing containers
when using resin-sync.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/resin-io/resin-supervisor/158)
<!-- Reviewable:end -->
