### PR TITLE
Switch to docker-delta library to use deltas v2

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "body-parser": "^1.12.0",
     "buffer-equal-constant-time": "^1.0.1",
     "coffee-script": "~1.9.1",
+    "docker-delta": "0.0.5",
     "docker-progress": "^2.1.0",
     "dockerode": "~2.2.9",
     "event-stream": "^3.0.20",


### PR DESCRIPTION
This npm library implements the new delta format and also works with
docker 1.10.

Signed-off-by: Petros Angelatos <petrosagg@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/resin-io/resin-supervisor/159)
<!-- Reviewable:end -->
