### PR TITLE
bump node-docker-delta version to 0.0.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+* Cleanup docker images if delta failed [petrosagg]
 * Make the data path configurable [Pablo]
 
 # v1.11.3

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "body-parser": "^1.12.0",
     "buffer-equal-constant-time": "^1.0.1",
     "coffee-script": "~1.9.1",
-    "docker-delta": "0.0.9",
+    "docker-delta": "0.0.10",
     "docker-progress": "^2.1.0",
     "dockerode": "~2.2.9",
     "event-stream": "^3.0.20",


### PR DESCRIPTION
this version fixes the issue where failed attempts to apply the delta
result in a lot of docker images on the disk, which could also
potentially lead to out of space issues

Signed-off-by: Petros Angelatos <petrosagg@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/resin-io/resin-supervisor/169)
<!-- Reviewable:end -->
