### PR TITLE
Add proxy support and CA Root Cert

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,9 +6,14 @@ ifdef https_proxy
 	DOCKER_HTTPS_PROXY=--build-arg https_proxy=$(https_proxy)
 endif
 
+ifdef no_proxy
+	DOCKER_HTTPS_PROXY=--build-arg no_proxy=$(no_proxy)
+endif
+
 ifdef use_proxy_at_runtime
 	rt_http_proxy=$(http_proxy)
 	rt_https_proxy=$(https_proxy)
+	rt_no_proxy=$(no_proxy)
 endif
 
 DISABLE_CACHE= 'false'
@@ -97,6 +102,9 @@ endif
 ifdef rt_http_proxy
 	echo "ENV HTTP_PROXY $(rt_http_proxy)" >> Dockerfile
 	echo "ENV http_proxy $(rt_http_proxy)" >> Dockerfile
+endif
+ifdef rt_no_proxy
+	echo "ENV no_proxy $(rt_no_proxy)" >> Dockerfile
 endif
 	docker build $(DOCKER_HTTP_PROXY) $(DOCKER_HTTPS_PROXY) --no-cache=$(DISABLE_CACHE) -t $(IMAGE) .
 	-rm Dockerfile

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,12 @@ ifdef https_proxy
 	DOCKER_HTTPS_PROXY=--build-arg https_proxy=$(https_proxy)
 endif
 
-DISABLE_CACHE = 'false'
+ifdef use_proxy_at_runtime
+	rt_http_proxy=$(http_proxy)
+	rt_https_proxy=$(https_proxy)
+endif
+
+DISABLE_CACHE= 'false'
 
 ARCH = rpi# rpi/amd64/i386/armv7hf/armel
 BASE_DISTRO =
@@ -85,13 +90,13 @@ supervisor: gosuper
 	echo "ENV DEFAULT_PUBNUB_PUBLISH_KEY $(PUBNUB_PUBLISH_KEY)" >> Dockerfile
 	echo "ENV DEFAULT_PUBNUB_SUBSCRIBE_KEY $(PUBNUB_SUBSCRIBE_KEY)" >> Dockerfile
 	echo "ENV DEFAULT_MIXPANEL_TOKEN $(MIXPANEL_TOKEN)" >> Dockerfile
-ifdef https_proxy
-	echo "ENV HTTPS_PROXY $(https_proxy)" >> Dockerfile
-	echo "ENV https_proxy $(https_proxy)" >> Dockerfile
+ifdef rt_https_proxy
+	echo "ENV HTTPS_PROXY $(rt_https_proxy)" >> Dockerfile
+	echo "ENV https_proxy $(rt_https_proxy)" >> Dockerfile
 endif
-ifdef http_proxy
-	echo "ENV HTTP_PROXY $(http_proxy)" >> Dockerfile
-	echo "ENV http_proxy $(http_proxy)" >> Dockerfile
+ifdef rt_http_proxy
+	echo "ENV HTTP_PROXY $(rt_http_proxy)" >> Dockerfile
+	echo "ENV http_proxy $(rt_http_proxy)" >> Dockerfile
 endif
 	docker build $(DOCKER_HTTP_PROXY) $(DOCKER_HTTPS_PROXY) --no-cache=$(DISABLE_CACHE) -t $(IMAGE) .
 	-rm Dockerfile

--- a/Makefile
+++ b/Makefile
@@ -108,23 +108,19 @@ go-builder:
 gosuper: go-builder
 	-mkdir -p bin
 	-docker rm --volumes -f resin_build_gosuper_$(JOB_NAME) || true
-	docker run --name resin_build_gosuper_$(JOB_NAME) -v $(shell pwd)/gosuper/bin:/usr/src/app/bin -e USER_ID=$(shell id -u) -e GROUP_ID=$(shell id -g) -e GOARCH=$(GOARCH) -e GOARM=$(GOARM) resin/go-supervisor-builder:$(SUPERVISOR_VERSION)
-	docker rm --volumes -f resin_build_gosuper_$(JOB_NAME)
+	docker run --rm --name resin_build_gosuper_$(JOB_NAME) -v $(shell pwd)/gosuper/bin:/usr/src/app/bin -e USER_ID=$(shell id -u) -e GROUP_ID=$(shell id -g) -e GOARCH=$(GOARCH) -e GOARM=$(GOARM) resin/go-supervisor-builder:$(SUPERVISOR_VERSION)
 	mv gosuper/bin/linux_$(GOARCH)/gosuper bin/gosuper
 
 test-gosuper: go-builder
 	-docker rm --volumes -f resin_test_gosuper_$(JOB_NAME) || true
-	docker run --name resin_test_gosuper_$(JOB_NAME) -v /var/run/dbus:/mnt/root/run/dbus -e DBUS_SYSTEM_BUS_ADDRESS="unix:path=/mnt/root/run/dbus/system_bus_socket" resin/go-supervisor-builder:$(SUPERVISOR_VERSION) bash -c "cd src/resin-supervisor/gosuper && ./test_formatting.sh && go test -v ./gosuper"
-	docker rm --volumes -f resin_test_gosuper_$(JOB_NAME)
+	docker run --rm --name resin_test_gosuper_$(JOB_NAME) -v /var/run/dbus:/mnt/root/run/dbus -e DBUS_SYSTEM_BUS_ADDRESS="unix:path=/mnt/root/run/dbus/system_bus_socket" resin/go-supervisor-builder:$(SUPERVISOR_VERSION) bash -c "cd src/resin-supervisor/gosuper && ./test_formatting.sh && go test -v ./gosuper"
 
 format-gosuper: go-builder
 	-docker rm --volumes -f resin_test_gosuper_$(JOB_NAME) || true
-	docker run --name resin_test_gosuper_$(JOB_NAME) -v $(shell pwd)/gosuper:/usr/src/app/src/resin-supervisor/gosuper resin/go-supervisor-builder:$(SUPERVISOR_VERSION) bash -c "cd src/resin-supervisor/gosuper && go fmt ./..."
-	docker rm --volumes -f resin_test_gosuper_$(JOB_NAME)
+	docker run --rm --name resin_test_gosuper_$(JOB_NAME) -v $(shell pwd)/gosuper:/usr/src/app/src/resin-supervisor/gosuper resin/go-supervisor-builder:$(SUPERVISOR_VERSION) bash -c "cd src/resin-supervisor/gosuper && go fmt ./..."
 
 test-integration: go-builder
 	-docker rm --volumes -f resin_test_integration_$(JOB_NAME) || true
-	docker run --name resin_test_integration_$(JOB_NAME) --net=host -e SUPERVISOR_IP="$(shell docker inspect --format '{{ .NetworkSettings.IPAddress }}' resin_supervisor_1)" --volumes-from resin_supervisor_1 -v /var/run/dbus:/mnt/root/run/dbus -e DBUS_SYSTEM_BUS_ADDRESS="unix:path=/mnt/root/run/dbus/system_bus_socket" resin/go-supervisor-builder:$(SUPERVISOR_VERSION) bash -c "cd src/resin-supervisor/gosuper && go test -v ./supertest"
-	docker rm --volumes -f resin_test_integration_$(JOB_NAME)
+	docker run --rm --name resin_test_integration_$(JOB_NAME) --net=host -e SUPERVISOR_IP="$(shell docker inspect --format '{{ .NetworkSettings.IPAddress }}' resin_supervisor_1)" --volumes-from resin_supervisor_1 -v /var/run/dbus:/mnt/root/run/dbus -e DBUS_SYSTEM_BUS_ADDRESS="unix:path=/mnt/root/run/dbus/system_bus_socket" resin/go-supervisor-builder:$(SUPERVISOR_VERSION) bash -c "cd src/resin-supervisor/gosuper && go test -v ./supertest"
 
 .PHONY: supervisor deploy supervisor-dind run-supervisor

--- a/tools/dind/Dockerfile
+++ b/tools/dind/Dockerfile
@@ -16,6 +16,9 @@ ENV RELEASE_NAME jessie
 # Change to 'true' to allow blank password dropbear logins on dind HostOS
 ENV PASSWORDLESS_DROPBEAR false
 
+COPY config/certs/ /usr/local/share/ca-certificates/
+RUN rm -f /usr/local/share/ca-certificates/.keepme ; update-ca-certificates
+
 RUN apt-key adv --keyserver hkp://pgp.mit.edu:80 --recv-keys 58118E89F3A912897C070ADBF76221572C52609D \
 	&& echo deb https://apt.dockerproject.org/repo debian-${RELEASE_NAME} main > /etc/apt/sources.list.d/docker.list \
 	&& apt-get update || true \


### PR DESCRIPTION
Adding proxy suport and CA Root certs additions in to runing supervisor image.
       Integrating http_proxy https_proxy environment variables into docker build and final docker image
       Remove go build run containers
       adding support to include internal CA Certs used by (an example) proxy servers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/resin-io/resin-supervisor/185)
<!-- Reviewable:end -->
