### PR TITLE
dind: add helper scripts to speed-up development with bind mounts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ ifdef use_proxy_at_runtime
 	rt_no_proxy=$(no_proxy)
 endif
 
-DISABLE_CACHE= 'false'
+DISABLE_CACHE = 'false'
 
 ARCH = rpi# rpi/amd64/i386/armv7hf/armel
 BASE_DISTRO =
@@ -70,6 +70,8 @@ else
 	PRELOADED_IMAGE=
 endif
 
+SUPERVISOR_EXTRA_MOUNTS =
+
 clean:
 	-rm Dockerfile
 
@@ -78,7 +80,7 @@ supervisor-dind:
 
 run-supervisor: supervisor-dind stop-supervisor
 	cd tools/dind \
-	&& echo "SUPERVISOR_IMAGE=$(SUPERVISOR_IMAGE)\nPRELOADED_IMAGE=$(PRELOADED_IMAGE)" > config/localenv \
+	&& echo "SUPERVISOR_IMAGE=$(SUPERVISOR_IMAGE)\nPRELOADED_IMAGE=$(PRELOADED_IMAGE)\nSUPERVISOR_EXTRA_MOUNTS=$(SUPERVISOR_EXTRA_MOUNTS)" > config/localenv \
 	&& docker run -d --name resin_supervisor_1 --privileged ${SUPERVISOR_DIND_MOUNTS} resin/resin-supervisor-dind:$(SUPERVISOR_VERSION)
 
 stop-supervisor:

--- a/Makefile
+++ b/Makefile
@@ -90,6 +90,12 @@ stop-supervisor:
 	-docker stop resin_supervisor_1 > /dev/null || true
 	-docker rm -f --volumes resin_supervisor_1 > /dev/null || true
 
+refresh-supervisor:
+	echo " * Compiling CoffeeScript.." \
+	&& coffee -c ./src \
+	&& echo " * Restarting supervisor container.." \
+	&& docker exec -ti resin_supervisor_1 docker restart resin_supervisor
+
 supervisor: gosuper
 	cp Dockerfile.$(DOCKERFILE) Dockerfile
 	echo "ENV VERSION "`jq -r .version package.json` >> Dockerfile

--- a/Makefile
+++ b/Makefile
@@ -90,7 +90,7 @@ stop-supervisor:
 	-docker stop resin_supervisor_1 > /dev/null || true
 	-docker rm -f --volumes resin_supervisor_1 > /dev/null || true
 
-refresh-supervisor:
+refresh-supervisor-src:
 	echo " * Compiling CoffeeScript.." \
 	&& coffee -c ./src \
 	&& echo " * Restarting supervisor container.." \

--- a/tools/dev/dev_s.sh
+++ b/tools/dev/dev_s.sh
@@ -1,0 +1,96 @@
+#!/bin/bash
+
+set -o errexit
+set -o pipefail
+# set -o xtrace
+
+DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+SUPERVISOR_BASE_DIR="${DIR}/../.."
+
+ARCH=${ARCH:-"amd64"}
+DEPLOY_REGISTRY=${DEPLOY_REGISTRY:-"registry.resindev.io/"}
+PASSWORDLESS_DROPBEAR=${PASSWORDLESS_DROPBEAR:-"false"}
+SUPERVISOR_EXTRA_MOUNTS=
+
+function showHelp {
+	echo
+	echo "	This script can be used to facilitate supervisor development. Its core feature is allowing"
+	echo "	faster development iterations by bind-mounting the local './src' directly into the running"
+	echo "	supervisor container."
+	echo
+	echo "	Setting the '--mount-nm' flag in either 'bindrun' or 'deploybindrun' action will bind-mount"
+	echo "	'./node_modules/' into the running supervisor as well. In this case, it's up to the developer"
+	echo "	to make sure that the correct dependencies are installed."
+	echo
+	echo "	Usage: [environment] $0 action [options]"
+	echo
+	echo "	Environment Variables:"
+	echo "		ARCH [=amd64]"
+	echo "		DEPLOY_REGISTRY [=registry.resindev.io/]"
+	echo "		PASSWORDLESS_DROPBEAR [=false]"
+	echo "	Actions:"
+	echo "		deploy				build supervisor image and deploy it to the registry"
+	echo "		run [options]			build dind supervisor host container, run it, then pull supervisor container and run it as well"
+	echo "		deployrun [options]		run 'deploy' and 'run'"
+	echo "		refresh				recompile sources in './src' with 'coffee -c' and restart supervisor container on dind host"
+	echo "		stop				stop dind supervisor host container"
+	echo "	Options:"
+	echo "		--mount-src			bind-mount './src/' from local development environment into supervisor container"
+	echo "		--mount-nm			bind-mount './node_modules/' from local development environment into supervisor container"
+	echo
+}
+
+function deploySupervisor {
+	make -C "$SUPERVISOR_BASE_DIR" deploy
+}
+
+function runDind {
+	for arg in "$@"
+	do
+		case $arg in
+			--mount-src)
+				coffee -c "$SUPERVISOR_BASE_DIR/src"
+				SUPERVISOR_EXTRA_MOUNTS="$SUPERVISOR_EXTRA_MOUNTS -v /resin-supervisor/src:/app/src"
+				shift
+				;;
+			--mount-nm)
+				SUPERVISOR_EXTRA_MOUNTS="$SUPERVISOR_EXTRA_MOUNTS -v /resin-supervisor/node_modules:/app/node_modules"
+				shift
+				;;
+			*)
+				;;
+		esac
+	done
+
+	make -C "$SUPERVISOR_BASE_DIR" \
+		PASSWORDLESS_DROPBEAR="$PASSWORDLESS_DROPBEAR" \
+		SUPERVISOR_EXTRA_MOUNTS="$SUPERVISOR_EXTRA_MOUNTS" \
+		SUPERVISOR_IMAGE="registry.resindev.io/resin/${ARCH}-supervisor:master" \
+		run-supervisor
+}
+
+case $1 in
+	deploy)
+		deploySupervisor
+		;;
+	run)
+		shift
+		runDind "$@"
+		;;
+	deployrun)
+		shift
+		deploySupervisor && runDind "$@"
+		;;
+	refresh)
+		echo " * Compiling CoffeeScript.." \
+		&& coffee -c "$SUPERVISOR_BASE_DIR/src" \
+		&& echo " * Restarting supervisor container.." \
+		&& docker exec -ti resin_supervisor_1 docker restart resin_supervisor
+		;;
+	stop)
+		make -C "$SUPERVISOR_BASE_DIR" stop-supervisor
+		;;
+	*)
+		showHelp
+esac
+

--- a/tools/dev/dev_s.sh
+++ b/tools/dev/dev_s.sh
@@ -41,7 +41,11 @@ function showHelp {
 }
 
 function deploySupervisor {
-	make -C "$SUPERVISOR_BASE_DIR" deploy
+	make -C "$SUPERVISOR_BASE_DIR" \
+		ARCH="$ARCH" \
+		DEPLOY_REGISTRY="$DEPLOY_REGISTRY" \
+		PASSWORDLESS_DROPBEAR="$PASSWORDLESS_DROPBEAR" \
+		deploy
 }
 
 function runDind {
@@ -63,9 +67,10 @@ function runDind {
 	done
 
 	make -C "$SUPERVISOR_BASE_DIR" \
+		ARCH="$ARCH" \
 		PASSWORDLESS_DROPBEAR="$PASSWORDLESS_DROPBEAR" \
 		SUPERVISOR_EXTRA_MOUNTS="$SUPERVISOR_EXTRA_MOUNTS" \
-		SUPERVISOR_IMAGE="registry.resindev.io/resin/${ARCH}-supervisor:master" \
+		SUPERVISOR_IMAGE="${DEPLOY_REGISTRY}resin/${ARCH}-supervisor:master" \
 		run-supervisor
 }
 

--- a/tools/dev/dindctl
+++ b/tools/dev/dindctl
@@ -8,7 +8,7 @@ DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 SUPERVISOR_BASE_DIR="${DIR}/../.."
 
 ARCH=${ARCH:-"amd64"}
-DEPLOY_REGISTRY=${DEPLOY_REGISTRY:-"registry.resindev.io/"}
+SUPERVISOR_IMAGE=${SUPERVISOR_IMAGE:-"registry.resindev.io/resin/${ARCH}-supervisor:master"}
 PASSWORDLESS_DROPBEAR=${PASSWORDLESS_DROPBEAR:-"false"}
 SUPERVISOR_EXTRA_MOUNTS=
 
@@ -18,20 +18,20 @@ function showHelp {
 	echo "	faster development iterations by bind-mounting the local './src' directly into the running"
 	echo "	supervisor container."
 	echo
-	echo "	Setting the '--mount-nm' flag in either 'bindrun' or 'deploybindrun' action will bind-mount"
-	echo "	'./node_modules/' into the running supervisor as well. In this case, it's up to the developer"
+	echo "	Setting the '--mount-nm' flag in either 'run' or 'deployrun' action will bind-mount"
+	echo "	'./node_modules/' into the running supervisor. In this case, it's up to the developer"
 	echo "	to make sure that the correct dependencies are installed."
 	echo
 	echo "	Usage: [environment] $0 action [options]"
 	echo
 	echo "	Environment Variables:"
 	echo "		ARCH [=amd64]"
-	echo "		DEPLOY_REGISTRY [=registry.resindev.io/]"
+	echo "		SUPERVISOR_IMAGE [=registry.resindev.io/resin/<ARCH>-supervisor:master]"
 	echo "		PASSWORDLESS_DROPBEAR [=false]"
 	echo "	Actions:"
-	echo "		deploy				build supervisor image and deploy it to the registry"
-	echo "		run [options]			build dind supervisor host container, run it, then pull supervisor container and run it as well"
-	echo "		deployrun [options]		run 'deploy' and 'run'"
+	echo "		deploy				build and deploy local supervisor image - you can override registry/image name with 'SUPERVISOR_IMAGE'"
+	echo "		run [options]			build dind supervisor host container, run it, then pull the configured 'SUPERVISOR_IMAGE' and run it"
+	echo "		deployrun [options]		run 'deploy' and then immediately 'run' the deployed container"
 	echo "		refresh				recompile sources in './src' with 'coffee -c' and restart supervisor container on dind host"
 	echo "		stop				stop dind supervisor host container"
 	echo "	Options:"
@@ -43,7 +43,7 @@ function showHelp {
 function deploySupervisor {
 	make -C "$SUPERVISOR_BASE_DIR" \
 		ARCH="$ARCH" \
-		DEPLOY_REGISTRY="$DEPLOY_REGISTRY" \
+		SUPERVISOR_IMAGE="$SUPERVISOR_IMAGE" \
 		PASSWORDLESS_DROPBEAR="$PASSWORDLESS_DROPBEAR" \
 		deploy
 }
@@ -68,9 +68,9 @@ function runDind {
 
 	make -C "$SUPERVISOR_BASE_DIR" \
 		ARCH="$ARCH" \
+		SUPERVISOR_IMAGE="$SUPERVISOR_IMAGE" \
 		PASSWORDLESS_DROPBEAR="$PASSWORDLESS_DROPBEAR" \
 		SUPERVISOR_EXTRA_MOUNTS="$SUPERVISOR_EXTRA_MOUNTS" \
-		SUPERVISOR_IMAGE="${DEPLOY_REGISTRY}resin/${ARCH}-supervisor:master" \
 		run-supervisor
 }
 
@@ -87,10 +87,7 @@ case $1 in
 		deploySupervisor && runDind "$@"
 		;;
 	refresh)
-		echo " * Compiling CoffeeScript.." \
-		&& coffee -c "$SUPERVISOR_BASE_DIR/src" \
-		&& echo " * Restarting supervisor container.." \
-		&& docker exec -ti resin_supervisor_1 docker restart resin_supervisor
+		make -C "$SUPERVISOR_BASE_DIR" refresh-supervisor
 		;;
 	stop)
 		make -C "$SUPERVISOR_BASE_DIR" stop-supervisor

--- a/tools/dev/dindctl
+++ b/tools/dev/dindctl
@@ -2,7 +2,6 @@
 
 set -o errexit
 set -o pipefail
-# set -o xtrace
 
 DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 SUPERVISOR_BASE_DIR="${DIR}/../.."
@@ -11,6 +10,12 @@ ARCH=${ARCH:-"amd64"}
 SUPERVISOR_IMAGE=${SUPERVISOR_IMAGE:-"registry.resindev.io/resin/${ARCH}-supervisor:master"}
 PASSWORDLESS_DROPBEAR=${PASSWORDLESS_DROPBEAR:-"false"}
 SUPERVISOR_EXTRA_MOUNTS=
+
+SUPERVISOR_LOGS=(
+	'/var/log/supervisor-log/go_supervisor_stdout.log'
+	'/var/log/supervisor-log/resin_supervisor_stdout.log'
+	'/var/log/supervisor-log/supervisor/supervisord.log'
+)
 
 function showHelp {
 	echo
@@ -30,9 +35,10 @@ function showHelp {
 	echo "		PASSWORDLESS_DROPBEAR [=false]"
 	echo "	Actions:"
 	echo "		deploy				build and deploy local supervisor image - you can override registry/image name with 'SUPERVISOR_IMAGE'"
-	echo "		run [options]			build dind supervisor host container, run it, then pull the configured 'SUPERVISOR_IMAGE' and run it"
+	echo "		run [options]			build dind host container, run it, then pull the configured 'SUPERVISOR_IMAGE' into the dind host and run it"
 	echo "		deployrun [options]		run 'deploy' and then immediately 'run' the deployed container"
 	echo "		refresh				recompile sources in './src' with 'coffee -c' and restart supervisor container on dind host"
+	echo "		logs [-f]			print out supervisor log files - use '-f' to follow instead"
 	echo "		stop				stop dind supervisor host container"
 	echo "	Options:"
 	echo "		--mount-src			bind-mount './src/' from local development environment into supervisor container"
@@ -62,6 +68,7 @@ function runDind {
 				shift
 				;;
 			*)
+				echo "Warning: unknown argument: $arg"
 				;;
 		esac
 	done
@@ -74,20 +81,35 @@ function runDind {
 		run-supervisor
 }
 
-case $1 in
+function logs {
+	if [ "$1" = "-f" ]; then
+		docker exec -ti resin_supervisor_1 tail -f ${SUPERVISOR_LOGS[@]}
+	else
+		for log in "${SUPERVISOR_LOGS[@]}"; do
+			echo "	== ${log} =="
+			docker exec -ti resin_supervisor_1 cat "$log"
+		done
+	fi
+}
+
+action="$1"
+shift || true
+
+case $action in
 	deploy)
 		deploySupervisor
 		;;
 	run)
-		shift
 		runDind "$@"
 		;;
 	deployrun)
-		shift
 		deploySupervisor && runDind "$@"
 		;;
 	refresh)
-		make -C "$SUPERVISOR_BASE_DIR" refresh-supervisor
+		make -C "$SUPERVISOR_BASE_DIR" refresh-supervisor-src
+		;;
+	logs)
+		logs "$@"
 		;;
 	stop)
 		make -C "$SUPERVISOR_BASE_DIR" stop-supervisor

--- a/tools/dind/config/services/resin-supervisor-dind.service
+++ b/tools/dind/config/services/resin-supervisor-dind.service
@@ -24,6 +24,7 @@ ExecStart=/bin/bash -c 'source /usr/src/app/resin-vars && \
 	-v /var/log/supervisor-log:/var/log \
 	-v /:/mnt/root \
 	-v /etc/resolv.conf:/etc/resolv.conf:rw \
+	${SUPERVISOR_EXTRA_MOUNTS} \
 	-e "API_ENDPOINT=$API_ENDPOINT" \
 	-e "REGISTRY_ENDPOINT=$REGISTRY_ENDPOINT" \
 	-e "PUBNUB_SUBSCRIBE_KEY=$PUBNUB_SUBSCRIBE_KEY" \


### PR DESCRIPTION
Workflow examples:

##### 1. Simply deploy and run supervisor-dind (no bind mounting)

```bash
~# ./tools/dev/dindctl deployrun
```

##### 2. Deploy and run supervisor-dind with `./src` bind-mounted into the running supervisor container:

```bash
~# ./tools/dev/dindctl deployrun --mount-src
```

##### 3. Deploy and run supervisor-dind with `./src` *and* `./node_modules` bind-mounted into the running supervisor container:

```bash
~# ./tools/dev/dindctl deployrun --mount-src --mount-nm
```

##### 4. Quickly reflect changes from local, bind-mounted `./src` to the running application container:

```bash
~# time ./tools/dev/dindctl refresh                                           
 * Compiling CoffeeScript..
 * Restarting supervisor container..
resin_supervisor
./tools/dev/dindctl refresh  1.48s user 0.18s system 14% cpu 11.475 total
```

Connects to #184

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/resin-io/resin-supervisor/192)
<!-- Reviewable:end -->
