### PR TITLE
Change the logger to send at a specific interval and with a different…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+* **[Breaking]** Change the logger to send at a specific interval and with a different message format [Pablo]
+
 # v1.14.0
 
 * Allow using an HTTP header for auth [Pablo]

--- a/src/application.coffee
+++ b/src/application.coffee
@@ -77,7 +77,7 @@ logTypes =
 		humanName: 'Restarting application'
 
 logSystemMessage = (message, obj, eventName) ->
-	logger.log({ message, isSystem: true })
+	logger.log({ m: message, s: true })
 	utils.mixpanelTrack(eventName ? message, obj)
 
 logSystemEvent = (logType, app, error) ->

--- a/src/application.coffee
+++ b/src/application.coffee
@@ -77,7 +77,7 @@ logTypes =
 		humanName: 'Restarting application'
 
 logSystemMessage = (message, obj, eventName) ->
-	logger.log({ m: message, s: true })
+	logger.log({ m: message, s: 1 })
 	utils.mixpanelTrack(eventName ? message, obj)
 
 logSystemEvent = (logType, app, error) ->

--- a/src/lib/logger.coffee
+++ b/src/lib/logger.coffee
@@ -5,6 +5,13 @@ Promise = require 'bluebird'
 es = require 'event-stream'
 Lock = require 'rwlock'
 
+LOG_PUBLISH_INTERVAL = 110
+
+# Pubnub's message size limit is 32KB (unclear on whether it's KB or actually KiB,
+# but we'll be conservative). So we limit a log message to 2 bytes less to account
+# for the [ and ] in the array.
+MAX_LOG_BYTE_SIZE = 31998
+
 disableLogs = false
 
 initialised = new Promise (resolve) ->
@@ -21,6 +28,7 @@ dockerPromise = initialised.then (config) ->
 # Queue up any calls to publish logs whilst we wait to be initialised.
 publish = do ->
 	publishQueue = []
+	publishQueueRemainingBytes = MAX_LOG_BYTE_SIZE
 
 	initialised.then (config) ->
 		if config.offlineMode
@@ -29,25 +37,26 @@ publish = do ->
 			return
 		pubnub = PUBNUB.init(config.pubnub)
 		channel = config.channel
+		doPublish = ->
+			return if publishQueue.length is 0
+			pubnub.publish({ channel, message: publishQueue })
+			publishQueue = []
+			publishQueueRemainingBytes = MAX_LOG_BYTE_SIZE
+		setInterval(doPublish, LOG_PUBLISH_INTERVAL)
 
-		# Redefine original function
-		publish = (message) ->
-			# Disable sending logs for bandwidth control
-			return if disableLogs
-			if _.isString(message)
-				message = { message }
+	return (message) ->
+		# Disable sending logs for bandwidth control
+		return if disableLogs or publishQueueRemainingBytes <= 0
+		if _.isString(message)
+			message = { m: message }
 
-			_.defaults message,
-				timestamp: Date.now()
-				# Stop pubnub logging loads of "Missing Message" errors, as they are quite distracting
-				message: ' '
+		_.defaults message,
+			t: Date.now()
+			m: ''
+		msgLength = Buffer.byteLength(JSON.stringify(message), 'utf8')
+		publishQueueRemainingBytes -= msgLength
+		publishQueue.push(message) if publishQueueRemainingBytes >= 0
 
-			pubnub.publish({ channel, message })
-
-		# Replay queue now that we have initialised the publish function
-		publish(args...) for args in publishQueue
-
-	return -> publishQueue.push(arguments)
 
 # disable: A Boolean to pause the Log Publishing - Logs are lost when paused.
 exports.disableLogPublishing = (disable) ->

--- a/src/lib/logger.coffee
+++ b/src/lib/logger.coffee
@@ -10,7 +10,7 @@ LOG_PUBLISH_INTERVAL = 110
 # Pubnub's message size limit is 32KB (unclear on whether it's KB or actually KiB,
 # but we'll be conservative). So we limit a log message to 2 bytes less to account
 # for the [ and ] in the array.
-MAX_LOG_BYTE_SIZE = 31998
+MAX_LOG_BYTE_SIZE = 30000
 MAX_MESSAGE_INDEX = 9
 
 disableLogs = false
@@ -60,7 +60,7 @@ publish = do ->
 		_.defaults message,
 			t: Date.now()
 			m: ''
-		msgLength = Buffer.byteLength(JSON.stringify(message), 'utf8')
+		msgLength = Buffer.byteLength(encodeURIComponent(JSON.stringify(message)), 'utf8')
 		return if msgLength > MAX_LOG_BYTE_SIZE # Unlikely, but we can't allow this
 		remaining = publishQueueRemainingBytes - msgLength
 		if remaining >= 0


### PR DESCRIPTION
… message format

Log messages to PubNub are now an array instead of an object.
Each element of the array is an object with m (message), t (timestamp) and s (isSystem, optional) attributes.
Logs are sent at a specific interval (100ms, fit to PubNub's approximated 10 messages/s limit), and truncated to PubNub's 32KB limit.

connects to #174 

This proposed change affects Resin system-wide, as we'd need to change how we parse logs in the UI and the SDKs.
@petrosagg @Page- @alexandrosm @shaunmulligan

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/resin-io/resin-supervisor/213)
<!-- Reviewable:end -->
