### PR TITLE
Fix double-printed logs after container restart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+* Fix duplicate logs issue [Kostas]
 * **[Breaking]** Do not bind mount /run/dbus to /run/dbus [Pablo]
 * Default to not bind mounting kmod if container distro can't be found [Pablo]
 * Use log-timestamp to add timestamps to logs [Pablo]


### PR DESCRIPTION
Connects to #217 

Ref: https://github.com/resin-io-modules/resin-sync/issues/14

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/resin-io/resin-supervisor/218)
<!-- Reviewable:end -->
