### PR TITLE
WIP: Allow the supervisor to work in offline mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+* Allow the supervisor to work in offline mode [Pablo]
 * Fix duplicate logs issue [Kostas]
 * **[Breaking]** Do not bind mount /run/dbus to /run/dbus [Pablo]
 * Default to not bind mounting kmod if container distro can't be found [Pablo]

--- a/src/app.coffee
+++ b/src/app.coffee
@@ -20,16 +20,17 @@ knex.init.then ->
 		utils.mixpanelProperties.uuid = uuid
 
 		api = require './api'
-		application = require('./application')(logsChannel)
+		application = require('./application')(logsChannel, bootstrap.offlineMode)
 		device = require './device'
+
+		console.log('Starting API server..')
+		apiServer = api(application).listen(config.listenPort)
+		apiServer.timeout = config.apiTimeout
 
 		bootstrap.done
 		.then ->
 			device.getOSVersion()
 		.then (osVersion) ->
-			console.log('Starting API server..')
-			apiServer = api(application).listen(config.listenPort)
-			apiServer.timeout = config.apiTimeout
 			# Let API know what version we are, and our api connection info.
 			console.log('Updating supervisor version and api info')
 			device.updateState(

--- a/src/application.coffee
+++ b/src/application.coffee
@@ -703,10 +703,11 @@ application.initialize = ->
 		application.poll()
 		application.update()
 
-module.exports = (logsChannel) ->
+module.exports = (logsChannel, offlineMode) ->
 	logger.init(
 		dockerSocket: config.dockerSocket
 		pubnub: config.pubnub
 		channel: "device-#{logsChannel}-logs"
+		offlineMode: offlineMode
 	)
 	return application

--- a/src/lib/logger.coffee
+++ b/src/lib/logger.coffee
@@ -25,6 +25,7 @@ publish = do ->
 	initialised.then (config) ->
 		if config.offlineMode
 			publish = _.noop
+			publishQueue = null
 			return
 		pubnub = PUBNUB.init(config.pubnub)
 		channel = config.channel

--- a/src/lib/logger.coffee
+++ b/src/lib/logger.coffee
@@ -23,6 +23,9 @@ publish = do ->
 	publishQueue = []
 
 	initialised.then (config) ->
+		if config.offlineMode
+			publish = _.noop
+			return
 		pubnub = PUBNUB.init(config.pubnub)
 		channel = config.channel
 

--- a/src/utils.coffee
+++ b/src/utils.coffee
@@ -18,10 +18,14 @@ tagExtra = process.env.SUPERVISOR_TAG_EXTRA
 version += '+' + tagExtra if !_.isEmpty(tagExtra)
 exports.supervisorVersion = version
 
-mixpanelClient = mixpanel.init(config.mixpanelToken)
+configJson = require('/boot/config.json')
+if Boolean(configJson.supervisorOfflineMode)
+	mixpanelClient = mixpanel.init(config.mixpanelToken)
+else
+	mixpanelClient = { track: _.noop }
 
 exports.mixpanelProperties = mixpanelProperties =
-	username: require('/boot/config.json').username
+	username: configJson.username
 
 exports.mixpanelTrack = (event, properties = {}) ->
 	# Allow passing in an error directly and having it assigned to the error property.


### PR DESCRIPTION
connects to #220
A supervisorOfflineMode true-ish attribute in config.json will cause that:
* If unprovisioned, the supervisor won't try to provision on Resin
* The update cycle will not start as the device won't consider itself provisioned
* Logs will not be sent to pubnub
* Mixpanel events won't be tracked
* The device state won't be updated to the Resin API

This change will also make the Supervisor API work with an unprovisioned device.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/resin-io/resin-supervisor/219)
<!-- Reviewable:end -->