### PR TITLE
bootstrap: if offlineMode is enabled, persist only the uuid

### DIFF
--- a/src/bootstrap.coffee
+++ b/src/bootstrap.coffee
@@ -111,7 +111,10 @@ bootstrapper.startBootstrapping = ->
 		readConfigAndEnsureUUID()
 		.tap ->
 			loadPreloadedApps()
-		.tap ->
-			bootstrapOrRetry()
+		.tap (uuid) ->
+			if bootstrapper.offlineMode
+				return knex('config').insert({ key: 'uuid', value: uuid })
+			else
+				return bootstrapOrRetry()
 
 module.exports = bootstrapper


### PR DESCRIPTION
If we don't persist the uuid then every time the supervisor starts it
will think it's a new device. This triggers a wipe of the local state
and also a re-load of the preloaded apps. This in turn causes multiple
instances of the preloaded apps to be left running.

Signed-off-by: Petros Angelatos <petrosagg@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/resin-io/resin-supervisor/227)
<!-- Reviewable:end -->
