### PR TITLE
Add iptables rules to block requests to the supervisor API from all interfaces except vpn, docker and local

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+* Add iptables rules to block requests to the supervisor API from all interfaces except vpn, docker and local [Pablo]
+
 # v1.13.2
 
 * bootstrap: if offlineMode is enabled, persist only the uuid [petrosagg]

--- a/Dockerfile.amd64
+++ b/Dockerfile.amd64
@@ -11,6 +11,7 @@ RUN apt-get -q update \
 		btrfs-tools \
 		ca-certificates \
 		curl \
+		iptables \
 		rsync \
 		supervisor \
 		--no-install-recommends \

--- a/Dockerfile.armel
+++ b/Dockerfile.armel
@@ -11,6 +11,7 @@ RUN apt-get -q update \
 		btrfs-tools \
 		ca-certificates \
 		curl \
+		iptables \
 		rsync \
 		supervisor \
 		--no-install-recommends \

--- a/Dockerfile.armv7hf
+++ b/Dockerfile.armv7hf
@@ -11,6 +11,7 @@ RUN apt-get -q update \
 		btrfs-tools \
 		ca-certificates \
 		curl \
+		iptables \
 		rsync \
 		supervisor \
 		--no-install-recommends \

--- a/Dockerfile.i386
+++ b/Dockerfile.i386
@@ -11,6 +11,7 @@ RUN apt-get -q update \
 		btrfs-tools \
 		ca-certificates \
 		curl \
+		iptables \
 		rsync \
 		supervisor \
 		--no-install-recommends \

--- a/Dockerfile.rpi
+++ b/Dockerfile.rpi
@@ -11,6 +11,7 @@ RUN apt-get -q update \
 		btrfs-tools \
 		ca-certificates \
 		curl \
+		iptables \
 		rsync \
 		supervisor \
 		--no-install-recommends \

--- a/src/app.coffee
+++ b/src/app.coffee
@@ -24,8 +24,10 @@ knex.init.then ->
 		device = require './device'
 
 		console.log('Starting API server..')
-		apiServer = api(application).listen(config.listenPort)
-		apiServer.timeout = config.apiTimeout
+		utils.createIpTablesRules()
+		.then ->
+			apiServer = api(application).listen(config.listenPort)
+			apiServer.timeout = config.apiTimeout
 
 		bootstrap.done
 		.then ->

--- a/src/utils.coffee
+++ b/src/utils.coffee
@@ -11,6 +11,7 @@ randomHexString = require './lib/random-hex-string'
 request = Promise.promisifyAll require 'request'
 logger = require './lib/logger'
 TypedError = require 'typed-error'
+execAsync = Promise.promisify(require('child_process').exec)
 
 # Parses package.json and returns resin-supervisor's version
 version = require('../package.json').version
@@ -279,3 +280,10 @@ exports.validateKeys = (options, validSet) ->
 		return if !options?
 		invalidKeys = _.keys(_.omit(options, validSet))
 		throw new Error("Using #{invalidKeys.join(', ')} is not allowed.") if !_.isEmpty(invalidKeys)
+
+exports.createIpTablesRules = ->
+	allowedInterfaces = ['tun0', 'docker0', 'lo']
+	Promise.each allowedInterfaces, (iface) ->
+		execAsync("iptables -A INPUT -p tcp --dport #{config.listenPort} -i #{iface} -j ACCEPT")
+	.then ->
+		execAsync("iptables -A INPUT -p tcp --dport #{config.listenPort} -j REJECT")

--- a/src/utils.coffee
+++ b/src/utils.coffee
@@ -281,9 +281,14 @@ exports.validateKeys = (options, validSet) ->
 		invalidKeys = _.keys(_.omit(options, validSet))
 		throw new Error("Using #{invalidKeys.join(', ')} is not allowed.") if !_.isEmpty(invalidKeys)
 
+checkAndAddIptablesRule = (rule) ->
+	execAsync("iptables -C #{rule}")
+	.catch ->
+		execAsync("iptables -A #{rule}")
+
 exports.createIpTablesRules = ->
 	allowedInterfaces = ['tun0', 'docker0', 'lo']
 	Promise.each allowedInterfaces, (iface) ->
-		execAsync("iptables -A INPUT -p tcp --dport #{config.listenPort} -i #{iface} -j ACCEPT")
+		checkAndAddIptablesRule("INPUT -p tcp --dport #{config.listenPort} -i #{iface} -j ACCEPT")
 	.then ->
-		execAsync("iptables -A INPUT -p tcp --dport #{config.listenPort} -j REJECT")
+		checkAndAddIptablesRule("INPUT -p tcp --dport #{config.listenPort} -j REJECT")


### PR DESCRIPTION

connects to #228 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/resin-io/resin-supervisor/229)
<!-- Reviewable:end -->
