### PR TITLE
[Experimental] WIP: allow downloading deltas with torrents

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "rwlock": "^5.0.0",
     "sqlite3": "3.0.9",
     "typed-error": "~0.1.0",
+    "webtorrent": "^0.96.4",
     "yamljs": "^0.2.7"
   },
   "engines": {

--- a/src/application.coffee
+++ b/src/application.coffee
@@ -152,7 +152,9 @@ fetch = (app) ->
 		Promise.try ->
 			JSON.parse(app.env)
 		.then (env) ->
-			if env['RESIN_SUPERVISOR_DELTA'] == '1'
+			if env['SUPERVISOR_TORRENT_DELTA'] == '1' # Temporarily use a non-RESIN_ var for testing
+				dockerUtils.torrentImageWithProgress(app.imageId, onProgress)
+			else if env['RESIN_SUPERVISOR_DELTA'] == '1'
 				dockerUtils.rsyncImageWithProgress(app.imageId, onProgress)
 			else
 				dockerUtils.fetchImageWithProgress(app.imageId, onProgress)


### PR DESCRIPTION
PoC for using webtorrent to download the deltas from S3.
Absolutely experimental.

TODO:
- Evaluate security aspects
- Ensure torrents are cleaned up eventually
- On startup, check if there's torrents to seed

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/resin-io/resin-supervisor/246)

<!-- Reviewable:end -->
