### PR TITLE
Add iptables rules to allow resin-vpn named interface to be used by VPN

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+
+* Add iptables rules to allow resin-vpn named interface to be used by VPN [Praneeth]
 * Updated to coffee-script ~1.10.0 [Page]
 * Catch exec format error and provide friendlier error message [Aleksis]
 

--- a/src/utils.coffee
+++ b/src/utils.coffee
@@ -287,7 +287,7 @@ checkAndAddIptablesRule = (rule) ->
 		execAsync("iptables -A #{rule}")
 
 exports.createIpTablesRules = ->
-	allowedInterfaces = ['tun0', 'docker0', 'lo']
+	allowedInterfaces = ['resin-vpn', 'tun0', 'docker0', 'lo']
 	Promise.each allowedInterfaces, (iface) ->
 		checkAndAddIptablesRule("INPUT -p tcp --dport #{config.listenPort} -i #{iface} -j ACCEPT")
 	.then ->


### PR DESCRIPTION
Connects to #247

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/resin-io/resin-supervisor/248)
<!-- Reviewable:end -->
