### PR TITLE
Update to coffee-script ~1.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+* Updated to coffee-script ~1.10.0 [Page]
 * Catch exec format error and provide friendlier error message [Aleksis]
 
 # v2.1.0

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "bluebird": "^2.9.24",
     "body-parser": "^1.12.0",
     "buffer-equal-constant-time": "^1.0.1",
-    "coffee-script": "~1.9.1",
+    "coffee-script": "~1.10.0",
     "docker-delta": "0.0.11",
     "docker-progress": "^2.1.0",
     "docker-toolbelt": "^1.0.0",


### PR DESCRIPTION
Connects to #250 

The only change in the generated code is that in try/catch blocks where the error is not caught (no catch block, or no var used) then the error object name is now `_error` rather than `error` or `undefined` (?!) - no actual semantic differences

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/resin-io/resin-supervisor/251)
<!-- Reviewable:end -->
