### PR TITLE
DRY up calls to gosuper API, and use empty Host header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+* DRY up calls to gosuper API, and use empty Host header [Pablo]
+
 # v2.1.1
 
 * Add iptables rules to allow resin-vpn named interface to be used by VPN [Praneeth]

--- a/src/app.coffee
+++ b/src/app.coffee
@@ -8,6 +8,7 @@ utils = require './utils'
 bootstrap = require './bootstrap'
 config = require './config'
 request = require 'request'
+_ = require 'lodash'
 
 knex.init.then ->
 	utils.mixpanelTrack('Supervisor start')
@@ -50,13 +51,13 @@ knex.init.then ->
 		application.initialize()
 
 		updateIpAddr = ->
-			callback = (error, response, body ) ->
-				if !error && response.statusCode == 200 && body.Data.IPAddresses?
+			utils.gosuper.getAsync('/v1/ipaddr', { json: true })
+			.spread (response, body) ->
+				if response.statusCode == 200 && body.Data.IPAddresses?
 					device.updateState(
 						ip_address: body.Data.IPAddresses.join(' ')
 					)
-			request.get({ url: "#{config.gosuperAddress}/v1/ipaddr", json: true }, callback )
-
+			.catch(_.noop)
 		console.log('Starting periodic check for IP addresses..')
 		setInterval(updateIpAddr, 30 * 1000) # Every 30s
 		updateIpAddr()

--- a/src/device.coffee
+++ b/src/device.coffee
@@ -42,7 +42,7 @@ exports.getID = do ->
 				return devices[0].id
 
 exports.reboot = ->
-	request.postAsync(config.gosuperAddress + '/v1/reboot')
+	utils.gosuper.postAsync('/v1/reboot')
 
 exports.hostConfigEnvVarPrefix = 'RESIN_HOST_'
 bootConfigEnvVarPrefix = 'RESIN_HOST_CONFIG_'
@@ -83,7 +83,7 @@ exports.setHostConfig = (env, logMessage) ->
 setLogToDisplay = (env, logMessage) ->
 	if env['RESIN_HOST_LOG_TO_DISPLAY']?
 		enable = env['RESIN_HOST_LOG_TO_DISPLAY'] != '0'
-		request.postAsync(config.gosuperAddress + '/v1/set-log-to-display', { json: true, body: Enable: enable })
+		utils.gosuper.postAsync('/v1/set-log-to-display', { json: true, body: Enable: enable })
 		.spread (response, body) ->
 			if response.statusCode != 200
 				logMessage("Error setting log to display: #{body.Error}, Status:, #{response.statusCode}", { error: body.Error }, 'Set log to display error')

--- a/src/utils.coffee
+++ b/src/utils.coffee
@@ -177,10 +177,28 @@ exports.resinLogControl = (val) ->
 	logger.disableLogPublishing(val == 'false')
 	console.log('Logs enabled: ' + val)
 
+emptyHostRequest = request.defaults({ headers: Host: '' })
+gosuperRequest = (method, endpoint, options = {}, callback) ->
+	if _.isFunction(options)
+		callback = options
+		options = {}
+	options.method = method
+	options.url = config.gosuperAddress + endpoint
+	emptyHostRequest(options, callback)
+
+gosuperPost = _.partial(gosuperRequest, 'POST')
+gosuperGet = _.partial(gosuperRequest, 'GET')
+
+exports.gosuper = gosuper =
+	post: gosuperPost
+	get: gosuperGet
+	postAsync: Promise.promisify(gosuperPost)
+	getAsync: Promise.promisify(gosuperGet)
+
 # Callback function to enable/disable VPN
 exports.vpnControl = (val) ->
 	enable = val != 'false'
-	request.postAsync(config.gosuperAddress + '/v1/vpncontrol', { json: true, body: Enable: enable })
+	gosuper.postAsync('/v1/vpncontrol', { json: true, body: Enable: enable })
 	.spread (response, body) ->
 		if response.statusCode == 202
 			console.log('VPN enabled: ' + enable)


### PR DESCRIPTION
connects to #252
The Host header will allow requests to continue working when we move to Go 1.6 or above.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/resin-io/resin-supervisor/253)
<!-- Reviewable:end -->
