### PR TITLE
build: fix multiple env var definition syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+* Fix ENV bug in build process [petrosagg]
+
 # v2.2.0
 
 * Add resin-vpn interface IP filtering to gosupervisor [Praneeth]

--- a/Dockerfile.runtime.template
+++ b/Dockerfile.runtime.template
@@ -10,9 +10,9 @@ COPY ./build/%%ARCH%%/rootfs-overlay/ /
 
 VOLUME /data
 
-ENV CONFIG_MOUNT_POINT /boot/config.json \
-	LED_FILE /dev/null \
-	SUPERVISOR_IMAGE resin/%%ARCH%%-supervisor
+ENV CONFIG_MOUNT_POINT=/boot/config.json \
+	LED_FILE=/dev/null \
+	SUPERVISOR_IMAGE=resin/%%ARCH%%-supervisor
 
 CMD [ "/sbin/init" ]
 

--- a/Makefile
+++ b/Makefile
@@ -133,20 +133,20 @@ refresh-supervisor-src:
 
 supervisor: nodesuper gosuper
 	sed 's/%%ARCH%%/$(ARCH)/g' Dockerfile.runtime.template > Dockerfile.runtime.$(ARCH)
-	echo "ENV VERSION $(shell jq -r .version package.json) \\" >> Dockerfile.runtime.$(ARCH)
-	echo "    DEFAULT_PUBNUB_PUBLISH_KEY $(PUBNUB_PUBLISH_KEY) \\" >> Dockerfile.runtime.$(ARCH)
-	echo "    DEFAULT_PUBNUB_SUBSCRIBE_KEY $(PUBNUB_SUBSCRIBE_KEY) \\" >> Dockerfile.runtime.$(ARCH)
-	echo "    DEFAULT_MIXPANEL_TOKEN $(MIXPANEL_TOKEN)" >> Dockerfile.runtime.$(ARCH)
+	echo "ENV VERSION=$(shell jq -r .version package.json) \\" >> Dockerfile.runtime.$(ARCH)
+	echo "    DEFAULT_PUBNUB_PUBLISH_KEY=$(PUBNUB_PUBLISH_KEY) \\" >> Dockerfile.runtime.$(ARCH)
+	echo "    DEFAULT_PUBNUB_SUBSCRIBE_KEY=$(PUBNUB_SUBSCRIBE_KEY) \\" >> Dockerfile.runtime.$(ARCH)
+	echo "    DEFAULT_MIXPANEL_TOKEN=$(MIXPANEL_TOKEN)" >> Dockerfile.runtime.$(ARCH)
 ifdef rt_https_proxy
-	echo "ENV HTTPS_PROXY $(rt_https_proxy) \\" >> Dockerfile.runtime.$(ARCH)
-	echo "    https_proxy $(rt_https_proxy)" >> Dockerfile.runtime.$(ARCH)
+	echo "ENV HTTPS_PROXY=$(rt_https_proxy) \\" >> Dockerfile.runtime.$(ARCH)
+	echo "    https_proxy=$(rt_https_proxy)" >> Dockerfile.runtime.$(ARCH)
 endif
 ifdef rt_http_proxy
-	echo "ENV HTTP_PROXY $(rt_http_proxy) \\" >> Dockerfile.runtime.$(ARCH)
-	echo "    http_proxy $(rt_http_proxy)" >> Dockerfile.runtime.$(ARCH)
+	echo "ENV HTTP_PROXY=$(rt_http_proxy) \\" >> Dockerfile.runtime.$(ARCH)
+	echo "    http_proxy=$(rt_http_proxy)" >> Dockerfile.runtime.$(ARCH)
 endif
 ifdef rt_no_proxy
-	echo "ENV no_proxy $(rt_no_proxy)" >> Dockerfile.runtime.$(ARCH)
+	echo "ENV no_proxy=$(rt_no_proxy)" >> Dockerfile.runtime.$(ARCH)
 endif
 	docker build \
 		$(DOCKER_HTTP_PROXY) \


### PR DESCRIPTION
When an ENV command has multiple environment variables defined they
key/value should be separated by an equals sign, not by a space.

Signed-off-by: Petros Angelatos <petrosagg@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/resin-io/resin-supervisor/265)
<!-- Reviewable:end -->
