### PR TITLE
Use getRegistryAndName from docker-toolbelt 1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+* In cleanup, normalize all image tags for comparison [Pablo]
 * Use getRegistryAndName from docker-toolbelt 1.2.0 [Pablo]
 
 # v2.5.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+* Use getRegistryAndName from docker-toolbelt 1.2.0 [Pablo]
+
 # v2.5.0
 
 * Switch to v2 api to be able to set is_online [Page]

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "buffer-equal-constant-time": "^1.0.1",
     "docker-delta": "0.0.12",
     "docker-progress": "^2.1.0",
-    "docker-toolbelt": "^1.0.0",
+    "docker-toolbelt": "^1.2.0",
     "dockerode": "~2.2.9",
     "event-stream": "^3.0.20",
     "express": "^4.0.0",

--- a/src/docker-utils.coffee
+++ b/src/docker-utils.coffee
@@ -1,5 +1,5 @@
 Docker = require 'docker-toolbelt'
-{ getRegistryAndName, DockerProgress } = require 'docker-progress'
+{ DockerProgress } = require 'docker-progress'
 Promise = require 'bluebird'
 progress = require 'request-progress'
 dockerDelta = require 'docker-delta'
@@ -46,7 +46,7 @@ findSimilarImage = (repoTag) ->
 DELTA_REQUEST_TIMEOUT = 15 * 60 * 1000
 
 getRepoAndTag = (image) ->
-	getRegistryAndName(image)
+	docker.getRegistryAndName(image)
 	.then ({ registry, imageName, tagName }) ->
 		registry = registry.toString().replace(':443', '')
 		return { repo: "#{registry}/#{imageName}", tag: tagName }

--- a/src/docker-utils.coffee
+++ b/src/docker-utils.coffee
@@ -101,27 +101,32 @@ do ->
 		Promise.using readLockImages(), ->
 			dockerProgress.pull(image, onProgress)
 
-	supervisorTag = config.supervisorImage
-	if !/:/g.test(supervisorTag)
-		# If there is no tag then mark it as latest
-		supervisorTag += ':latest'
+	normalizeRepoTag = (image) ->
+		getRepoAndTag(image)
+		.then ({ repo, tag }) ->
+			buildRepoTag(repo, tag)
+
+	supervisorTagPromise = normalizeRepoTag(config.supervisorImage)
+
 	exports.cleanupContainersAndImages = ->
 		Promise.using writeLockImages(), ->
 			Promise.join(
 				knex('image').select('repoTag')
-				.map (image) ->
-					# Docker sometimes prepends 'docker.io/' to official images
-					return [ image.repoTag, 'docker.io/' + image.repoTag ]
-				.then(_.flatten)
+				.map ({ repoTag }) ->
+					normalizeRepoTag(repoTag)
 				knex('app').select()
 				.map ({ imageId }) ->
-					imageId + ':latest'
+					normalizeRepoTag(imageId)
 				knex('dependentApp').select()
 				.map ({ imageId }) ->
-					imageId + ':latest'
+					normalizeRepoTag(imageId)
+				supervisorTagPromise
 				docker.listImagesAsync()
-				(locallyCreatedTags, apps, dependentApps, images) ->
-					imageTags = _.map(images, 'RepoTags')
+				.map (image) ->
+					image.NormalizedRepoTags = Promise.map(image.RepoTags, normalizeRepoTag)
+					Promise.props(image)
+				(locallyCreatedTags, apps, dependentApps, supervisorTag, images) ->
+					imageTags = _.map(images, 'NormalizedRepoTags')
 					supervisorTags = _.filter imageTags, (tags) ->
 						_.contains(tags, supervisorTag)
 					appTags = _.filter imageTags, (tags) ->
@@ -137,9 +142,8 @@ do ->
 				docker.listContainersAsync(all: true)
 				.filter (containerInfo) ->
 					# Do not remove user apps.
-					getRepoAndTag(containerInfo.Image)
-					.then ({ repo, tag }) ->
-						repoTag = buildRepoTag(repo, tag)
+					normalizeRepoTag(containerInfo.Image)
+					.then (repoTag) ->
 						if _.contains(appTags, repoTag)
 							return false
 						if _.contains(locallyCreatedTags, repoTag)
@@ -154,7 +158,7 @@ do ->
 					.catch(_.noop)
 				.then ->
 					imagesToClean = _.reject images, (image) ->
-						_.any image.RepoTags, (tag) ->
+						_.any image.NormalizedRepoTags, (tag) ->
 							return _.contains(appTags, tag) or _.contains(supervisorTags, tag) or _.contains(locallyCreatedTags, tag)
 					Promise.map imagesToClean, (image) ->
 						Promise.map image.RepoTags.concat(image.Id), (tag) ->


### PR DESCRIPTION
Fixes #293 

Depends on https://github.com/resin-io-modules/docker-toolbelt/pull/2 being merged and published as 1.2.0.