### PR TITLE
Improvements on config and dependent device handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+* Store config vars when there's nothing else to update [Pablo]
+* Do not mark an update as failed if the hook failed [Pablo]
+* When hitting the dependent devices hook, send appId as int [Pablo]
 * Updated to lodash 4 [Page]
 * Updated to coffeescript 1.11 [Page]
 * In delete-then-download, only delete when a download is needed [Pablo]

--- a/src/docker-utils.coffee
+++ b/src/docker-utils.coffee
@@ -117,7 +117,7 @@ do ->
 				knex('app').select()
 				.map ({ imageId }) ->
 					normalizeRepoTag(imageId)
-				knex('dependentApp').select()
+				knex('dependentApp').select().whereNotNull('imageId')
 				.map ({ imageId }) ->
 					normalizeRepoTag(imageId)
 				supervisorTagPromise


### PR DESCRIPTION
* Store config vars when there's nothing else to update
* Do not mark an update as failed if the hook failed
* When hitting the dependent devices hook, send appId as int

Fixes #299 
Fixes #298 
Fixes #291 

