### PR TITLE
Avoid installing npm dependencies twice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+* Avoid installing npm dependencies twice [Pablo]
 * Updated to bluebird 3 [Page]
 * Better parameter handling in PUT /v1/devices/:uuid [Pablo]
 * An update hook response of 200 will cause the proxyvisor to stop pinging the hook [Pablo]

--- a/Dockerfile.build.template
+++ b/Dockerfile.build.template
@@ -40,17 +40,17 @@ RUN set -x \
 
 COPY package.json /usr/src/app/
 
-# First install devDependencies too in order to run the build
-RUN JOBS=MAX npm install --unsafe-perm
+# Install only the production modules
+RUN JOBS=MAX npm install --production --no-optional --unsafe-perm \
+	&& npm dedupe
 
 COPY src /usr/src/app/src
 
-RUN npm run lint \
-	&& npm run build
-
-# Re-install just production modules. This should be fast due to npm cache from previous layer
-RUN rm -rf node_modules \
-	&& JOBS=MAX npm install --unsafe-perm --production --no-optional \
+# Install devDependencies, build the coffeescript and then prune the deps
+RUN npm install --only=dev --no-optional --unsafe-perm \
+	&& npm run lint \
+	&& npm run build \
+	&& npm prune --production \
 	&& npm dedupe
 
 # Remove various uneeded filetypes in order to reduce space


### PR DESCRIPTION
Instead of installing all dependencies, then clearing node_modules and running a production install, we do it the other way round: first install production deps, then install dev deps, build and then clean them up using `npm prune`.