### PR TITLE
Do not use parsed JSON to compare dep. device state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+Do not use parsed JSON to compare dep. device state [Pablo]
+
 # v2.6.0
 
 * Fix docker utils getImageEnv by correctly parsing the returned array [Pablo]


### PR DESCRIPTION
In the current code, we store an object in `acknowledgedState` that has config and environment parsed with `JSON.parse`, and we compare that to the targetState which has those fields stringified.
This PR fixes this comparison.