### PR TITLE
Properly set device name, and set undefined arguments to setConfig as null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+* Properly set device name, and set undefined arguments to setConfig as null [Pablo]
+
 # v2.6.2
 
 * Updated knex to ~0.12.3

--- a/src/application.coffee
+++ b/src/application.coffee
@@ -594,7 +594,7 @@ application.update = update = (force) ->
 			.then ({ local, dependent }) ->
 				proxyvisor.fetchAndSetTargetsForDependentApps(dependent, fetch, apiKey)
 				.then ->
-					utils.setConfig('name', deviceName) if local.name != deviceName
+					utils.setConfig('name', local.name) if local.name != deviceName
 				.then ->
 					parseEnvAndFormatRemoteApps(local.apps, uuid, apiKey)
 			.then (remoteApps) ->

--- a/src/utils.coffee
+++ b/src/utils.coffee
@@ -150,7 +150,7 @@ exports.getConfig = getConfig = (key) ->
 	.then ([ conf ]) ->
 		return conf?.value
 
-exports.setConfig = (key, value) ->
+exports.setConfig = (key, value = null) ->
 	knex('config').update({ value }).where({ key })
 	.then (n) ->
 		knex('config').insert({ key, value }) if n == 0


### PR DESCRIPTION
The recent knex update causes that when we try to update a single value as undefined it will cause an sqlite error.
This also surfaced the fact that we're actually always setting the device name with the same value instead of using the value returned from the API.