### PR TITLE
gosuper: support i386 platforms without MMX instructions

### DIFF
--- a/gosuper/Dockerfile
+++ b/gosuper/Dockerfile
@@ -1,17 +1,44 @@
 # Build golang supervisor
-FROM golang:1.6
+FROM debian:jessie
 
 RUN apt-get update \
 	&& apt-get install -y \
+		build-essential \
+		curl \
 		rsync \
 		upx-ucl \
 	&& rm -rf /var/lib/apt/lists/
+
+ENV GOLANG_VERSION 1.6.3
+ENV GOLANG_DOWNLOAD_URL https://golang.org/dl/go$GOLANG_VERSION.linux-amd64.tar.gz
+ENV GOLANG_DOWNLOAD_SHA256 cdde5e08530c0579255d6153b08fdb3b8e47caabbe717bc7bcd7561275a87aeb
+
+COPY go-${GOLANG_VERSION}-patches /go-${GOLANG_VERSION}-patches
+
+RUN mkdir /usr/src/go \
+	&& cd /usr/src/go \
+	&& curl -L -o go.tar.gz $GOLANG_DOWNLOAD_URL \
+	&& echo "${GOLANG_DOWNLOAD_SHA256}  go.tar.gz" | sha256sum -c - \
+	&& tar xzf go.tar.gz -C /usr/local \
+	&& cd /usr/src \
+	&& rm -rf go \
+	&& export GOROOT_BOOTSTRAP=/usr/local/go-bootstrap \
+	&& cp -r /usr/local/go /usr/local/go-bootstrap \
+	&& cd /usr/local/go/src \
+	&& patch -p2 -i /go-${GOLANG_VERSION}-patches/0001-Revert-runtime-check-and-fail-early-with-a-message-i.patch \
+	&& patch -p2 -i /go-${GOLANG_VERSION}-patches/0002-implement-atomic-quadword-ops-with-FILD-FISTP.patch \
+	&& ./make.bash \
+	&& rm -rf /usr/local/go-bootstrap
+
+ENV GOPATH /go
+ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
 
 COPY . /go/src/resin-supervisor/gosuper
 
 WORKDIR /go/src/resin-supervisor/gosuper
 
 ENV GOOS linux
+ENV GO386=387
 
 ARG GOARCH=amd64
 ARG GOARM=''

--- a/gosuper/go-1.6.3-patches/0001-Revert-runtime-check-and-fail-early-with-a-message-i.patch
+++ b/gosuper/go-1.6.3-patches/0001-Revert-runtime-check-and-fail-early-with-a-message-i.patch
@@ -1,0 +1,81 @@
+From 0ea3a41d2dc8b222093f191e6c2b7c3c89ac4e87 Mon Sep 17 00:00:00 2001
+From: Petros Angelatos <petrosagg@gmail.com>
+Date: Thu, 20 Oct 2016 20:20:56 -0700
+Subject: [PATCH 1/2] Revert "runtime: check and fail early with a message if
+ MMX is not available on 386"
+
+This reverts commit 35e84546d7c3cc599dd5bf31ad86bf8d3d841d04.
+---
+ src/runtime/asm_386.s | 42 ------------------------------------------
+ 1 file changed, 42 deletions(-)
+
+diff --git a/src/runtime/asm_386.s b/src/runtime/asm_386.s
+index 4181859..942446e 100644
+--- a/src/runtime/asm_386.s
++++ b/src/runtime/asm_386.s
+@@ -26,32 +26,6 @@ TEXT runtime·rt0_go(SB),NOSPLIT,$0
+ 	MOVL	SP, (g_stack+stack_hi)(BP)
+ 	
+ 	// find out information about the processor we're on
+-#ifdef GOOS_nacl // NaCl doesn't like PUSHFL/POPFL
+-	JMP 	has_cpuid
+-#else
+-	// first see if CPUID instruction is supported.
+-	PUSHFL
+-	PUSHFL
+-	XORL	$(1<<21), 0(SP) // flip ID bit
+-	POPFL
+-	PUSHFL
+-	POPL	AX
+-	XORL	0(SP), AX
+-	POPFL	// restore EFLAGS
+-	TESTL	$(1<<21), AX
+-	JNE 	has_cpuid
+-#endif
+-
+-bad_proc: // show that the program requires MMX.
+-	MOVL	$2, 0(SP)
+-	MOVL	$bad_proc_msg<>(SB), 4(SP)
+-	MOVL	$0x3d, 8(SP)
+-	CALL	runtime·write(SB)
+-	MOVL	$1, 0(SP)
+-	CALL	runtime·exit(SB)
+-	INT	$3
+-
+-has_cpuid:
+ 	MOVL	$0, AX
+ 	CPUID
+ 	CMPL	AX, $0
+@@ -74,11 +48,6 @@ notintel:
+ 	MOVL	CX, AX // Move to global variable clobbers CX when generating PIC
+ 	MOVL	AX, runtime·cpuid_ecx(SB)
+ 	MOVL	DX, runtime·cpuid_edx(SB)
+-
+-	// Check for MMX support
+-	TESTL	$(1<<23), DX	// MMX
+-	JZ 	bad_proc
+-
+ nocpuinfo:	
+ 
+ 	// if there is an _cgo_init, call it to let it
+@@ -160,17 +129,6 @@ ok:
+ 	INT $3
+ 	RET
+ 
+-DATA	bad_proc_msg<>+0x00(SB)/8, $"This pro"
+-DATA	bad_proc_msg<>+0x08(SB)/8, $"gram can"
+-DATA	bad_proc_msg<>+0x10(SB)/8, $" only be"
+-DATA	bad_proc_msg<>+0x18(SB)/8, $" run on "
+-DATA	bad_proc_msg<>+0x20(SB)/8, $"processe"
+-DATA	bad_proc_msg<>+0x28(SB)/8, $"rs with "
+-DATA	bad_proc_msg<>+0x30(SB)/8, $"MMX supp"
+-DATA	bad_proc_msg<>+0x38(SB)/4, $"ort."
+-DATA	bad_proc_msg<>+0x3c(SB)/1, $0xa
+-GLOBL	bad_proc_msg<>(SB), RODATA, $0x3d
+-
+ DATA	runtime·mainPC+0(SB)/4,$runtime·main(SB)
+ GLOBL	runtime·mainPC(SB),RODATA,$4
+ 
+-- 
+2.10.0
+

--- a/gosuper/go-1.6.3-patches/0002-implement-atomic-quadword-ops-with-FILD-FISTP.patch
+++ b/gosuper/go-1.6.3-patches/0002-implement-atomic-quadword-ops-with-FILD-FISTP.patch
@@ -1,0 +1,91 @@
+From 973d55e9e319a895e406c89413563a2fc787e98c Mon Sep 17 00:00:00 2001
+From: Petros Angelatos <petrosagg@gmail.com>
+Date: Tue, 18 Oct 2016 08:13:44 -0700
+Subject: [PATCH 2/2] implement atomic quadword ops with FILD/FISTP
+
+Signed-off-by: Petros Angelatos <petrosagg@gmail.com>
+---
+ src/runtime/internal/atomic/asm_386.s | 21 ++++++++-------------
+ src/sync/atomic/asm_386.s             | 20 ++++++++------------
+ 2 files changed, 16 insertions(+), 25 deletions(-)
+
+diff --git a/src/runtime/internal/atomic/asm_386.s b/src/runtime/internal/atomic/asm_386.s
+index ce84fd8..cd91023 100644
+--- a/src/runtime/internal/atomic/asm_386.s
++++ b/src/runtime/internal/atomic/asm_386.s
+@@ -121,12 +121,10 @@ TEXT runtime∕internal∕atomic·Load64(SB), NOSPLIT, $0-12
+ 	JZ	2(PC)
+ 	MOVL	0, AX // crash with nil ptr deref
+ 	LEAL	ret_lo+4(FP), BX
+-	// MOVQ (%EAX), %MM0
+-	BYTE $0x0f; BYTE $0x6f; BYTE $0x00
+-	// MOVQ %MM0, 0(%EBX)
+-	BYTE $0x0f; BYTE $0x7f; BYTE $0x03
+-	// EMMS
+-	BYTE $0x0F; BYTE $0x77
++	// FILDQ (%EAX)
++	BYTE $0xdf; BYTE $0x28
++	// FISTPQ (%EBX)
++	BYTE $0xdf; BYTE $0x3b
+ 	RET
+ 
+ // void runtime∕internal∕atomic·Store64(uint64 volatile* addr, uint64 v);
+@@ -135,13 +133,10 @@ TEXT runtime∕internal∕atomic·Store64(SB), NOSPLIT, $0-12
+ 	TESTL	$7, AX
+ 	JZ	2(PC)
+ 	MOVL	0, AX // crash with nil ptr deref
+-	// MOVQ and EMMS were introduced on the Pentium MMX.
+-	// MOVQ 0x8(%ESP), %MM0
+-	BYTE $0x0f; BYTE $0x6f; BYTE $0x44; BYTE $0x24; BYTE $0x08
+-	// MOVQ %MM0, (%EAX)
+-	BYTE $0x0f; BYTE $0x7f; BYTE $0x00 
+-	// EMMS
+-	BYTE $0x0F; BYTE $0x77
++	// FILDQ 0x8(%ESP)
++	BYTE $0xdf; BYTE $0x6c; BYTE $0x24; BYTE $0x08
++	// FISTPQ (%EAX)
++	BYTE $0xdf; BYTE $0x38
+ 	// This is essentially a no-op, but it provides required memory fencing.
+ 	// It can be replaced with MFENCE, but MFENCE was introduced only on the Pentium4 (SSE2).
+ 	MOVL	$0, AX
+diff --git a/src/sync/atomic/asm_386.s b/src/sync/atomic/asm_386.s
+index 383d759..b706047 100644
+--- a/src/sync/atomic/asm_386.s
++++ b/src/sync/atomic/asm_386.s
+@@ -157,12 +157,10 @@ TEXT ·LoadUint64(SB),NOSPLIT,$0-12
+ 	TESTL	$7, AX
+ 	JZ	2(PC)
+ 	MOVL	0, AX // crash with nil ptr deref
+-	// MOVQ and EMMS were introduced on the Pentium MMX.
+-	// MOVQ (%EAX), %MM0
+-	BYTE $0x0f; BYTE $0x6f; BYTE $0x00
+-	// MOVQ %MM0, 0x8(%ESP)
+-	BYTE $0x0f; BYTE $0x7f; BYTE $0x44; BYTE $0x24; BYTE $0x08
+-	EMMS
++	// FILDQ (%EAX)
++	BYTE $0xdf; BYTE $0x28
++	// FISTPQ 0x8(%ESP)
++	BYTE $0xdf; BYTE $0x7c; BYTE $0x24; BYTE $0x08
+ 	RET
+ 
+ TEXT ·LoadUintptr(SB),NOSPLIT,$0-8
+@@ -188,12 +186,10 @@ TEXT ·StoreUint64(SB),NOSPLIT,$0-12
+ 	TESTL	$7, AX
+ 	JZ	2(PC)
+ 	MOVL	0, AX // crash with nil ptr deref
+-	// MOVQ and EMMS were introduced on the Pentium MMX.
+-	// MOVQ 0x8(%ESP), %MM0
+-	BYTE $0x0f; BYTE $0x6f; BYTE $0x44; BYTE $0x24; BYTE $0x08
+-	// MOVQ %MM0, (%EAX)
+-	BYTE $0x0f; BYTE $0x7f; BYTE $0x00 
+-	EMMS
++	// FILDQ 0x8(%ESP)
++	BYTE $0xdf; BYTE $0x6c; BYTE $0x24; BYTE $0x08
++	// FISTPQ (%EAX)
++	BYTE $0xdf; BYTE $0x38
+ 	// This is essentially a no-op, but it provides required memory fencing.
+ 	// It can be replaced with MFENCE, but MFENCE was introduced only on the Pentium4 (SSE2).
+ 	XORL	AX, AX
+-- 
+2.10.0
+


### PR DESCRIPTION
The intel quark and the gallileo have an x86 CPU that does not have MMX
extensions. Use a patched go that does not require those instructions for
atomics, and also enable the GO386=387 flag.

Signed-off-by: Petros Angelatos <petrosagg@gmail.com>