### PR TITLE
Fix multiple update loops appearing after a long period of updates failing.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+* Fixed multiple update loops appearing after a long period of updates failing. [Page]
 * Avoid restarting the app if the device name changes [Pablo]
 * Use appId in dependent app assets tar path, and only create the tar if it doesn't exist [Pablo]
 * Support AUFS by upgrading node-docker-delta to 1.0.0 and docker-toolbelt to 1.3.0 [Pablo]


### PR DESCRIPTION
This was getting annoying when I was developing and had multiple update loops flooding the logs, making it hard to look at a single attempt in isolation