### PR TITLE
Use multiArgs to promisify gosuper requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+* Use multiArgs to promisify gosuper requests [Pablo]
 * Also make it explicit in mixpanel events when it's a full image download [Pablo]
 * Log whether deltas are being used when downloading an app [Pablo]
 

--- a/src/utils.coffee
+++ b/src/utils.coffee
@@ -203,8 +203,8 @@ gosuperGet = _.partial(gosuperRequest, 'GET')
 exports.gosuper = gosuper =
 	post: gosuperPost
 	get: gosuperGet
-	postAsync: Promise.promisify(gosuperPost)
-	getAsync: Promise.promisify(gosuperGet)
+	postAsync: Promise.promisify(gosuperPost, multiArgs: true)
+	getAsync: Promise.promisify(gosuperGet, multiArgs: true)
 
 # Callback function to enable/disable VPN
 exports.vpnControl = (val) ->


### PR DESCRIPTION
With the bluebird update to v3, all requests to gosuper (most notably, getting the IP addresses) got broken as we use .spread, which requires the Promise to fulfill with an array. So we need to add multiArgs so that getAsync and postAsync return an array. 