### PR TITLE
Mount the docker socket in the default path for dind

### DIFF
--- a/tools/dind/config/services/resin-supervisor-dind.service
+++ b/tools/dind/config/services/resin-supervisor-dind.service
@@ -16,7 +16,7 @@ ExecStartPre=-/bin/touch /etc/resolv.conf
 ExecStart=/bin/bash -c 'source /usr/src/app/resin-vars && \
 	/usr/bin/docker run --rm --privileged --name resin_supervisor \
 	--net=host \
-	-v /var/run/docker.sock:/run/docker.sock \
+	-v /var/run/docker.sock:/var/run/docker.sock \
 	-v "${CONFIG_PATH}:/boot/config.json" \
 	-v "${APPS_PATH}:/boot/apps.json" \
 	-v /resin-data/resin-supervisor:/data \
@@ -36,6 +36,7 @@ ExecStart=/bin/bash -c 'source /usr/src/app/resin-vars && \
 	-e "DBUS_SYSTEM_BUS_ADDRESS=unix:path=/mnt/root/run/dbus/system_bus_socket" \
 	-e "RESIN_SUPERVISOR_SECRET=${RESIN_SUPERVISOR_SECRET}" \
 	-e "DOCKER_ROOT=/mnt/root/var/lib/docker" \
+	-e "DOCKER_SOCKET=/var/run/docker.sock" \
 	${SUPERVISOR_IMAGE}'
 TimeoutStartSec=0
 Restart=always


### PR DESCRIPTION
This fixes deltas in the docker-in-docker supervisor, analogous to https://github.com/resin-os/meta-resin/commit/92e65fcf3d13de6c2d65dea8eb404d367f6c35f3