### PR TITLE
Add Promise timeouts to all external requests

### DIFF
--- a/src/application.coffee
+++ b/src/application.coffee
@@ -533,6 +533,7 @@ getRemoteState = (uuid, apiKey) ->
 	, cachedResinApi.passthrough
 
 	cachedResinApi._request(requestParams)
+	.timeout(config.apiTimeout)
 	.catch (err) ->
 		console.error("Failed to get state for device #{uuid}. #{err}")
 		throw err

--- a/src/bootstrap.coffee
+++ b/src/bootstrap.coffee
@@ -33,6 +33,7 @@ bootstrap = ->
 		if userConfig.registered_at?
 			return userConfig
 		deviceRegister.register(resinApi, userConfig)
+		.timeout(config.apiTimeout)
 		.catch DuplicateUuidError, ->
 			resinApi.get
 				resource: 'device'
@@ -41,6 +42,7 @@ bootstrap = ->
 						uuid: userConfig.uuid
 				customOptions:
 					apikey: userConfig.apiKey
+			.timeout(config.apiTimeout)
 			.then ([ device ]) ->
 				return device
 		.then (device) ->

--- a/src/device.coffee
+++ b/src/device.coffee
@@ -35,6 +35,7 @@ exports.getID = do ->
 					customOptions:
 						apikey: apiKey
 				)
+				.timeout(config.apiTimeout)
 			.then (devices) ->
 				if devices.length is 0
 					throw new Error('Could not find this device?!')
@@ -192,6 +193,7 @@ do ->
 					body: stateDiff
 					customOptions:
 						apikey: apiKey
+				.timeout(config.apiTimeout)
 				.then ->
 					# Update the actual state.
 					_.merge(actualState, stateDiff)

--- a/src/docker-utils.coffee
+++ b/src/docker-utils.coffee
@@ -44,6 +44,7 @@ findSimilarImage = (repoTag) ->
 		return 'resin/scratch'
 
 DELTA_REQUEST_TIMEOUT = 15 * 60 * 1000
+DELTA_TOTAL_TIMEOUT = 30 * 60 * 1000
 
 getRepoAndTag = (image) ->
 	docker.getRegistryAndName(image)
@@ -90,6 +91,7 @@ do ->
 							.on('id', resolve)
 							.on('error', reject)
 					.on 'error', reject
+				.timeout(DELTA_TOTAL_TIMEOUT)
 			.then (id) ->
 				getRepoAndTag(imgDest)
 				.then ({ repo, tag }) ->

--- a/src/proxyvisor.coffee
+++ b/src/proxyvisor.coffee
@@ -67,6 +67,7 @@ router.post '/v1/devices', (req, res) ->
 				body: d
 				customOptions:
 					apikey: apiKey
+			.timeout(appConfig.apiTimeout)
 			.then (dev) ->
 				# If the response has id: null then something was wrong in the request
 				# but we don't know precisely what.
@@ -168,6 +169,7 @@ router.put '/v1/devices/:uuid', (req, res) ->
 						body: fieldsToUpdateOnAPI
 						customOptions:
 							apikey: apiKey
+					.timeout(appConfig.apiTimeout)
 			.then ->
 				knex('dependentDevice').update(fieldsToUpdateOnDB).where({ uuid })
 			.then ->
@@ -278,6 +280,7 @@ exports.fetchAndSetTargetsForDependentApps = (state, fetchFn, apiKey) ->
 								uuid: uuid
 						customOptions:
 							apikey: apiKey
+					.timeout(appConfig.apiTimeout)
 					.then ([ dev ]) ->
 						deviceForDB = {
 							uuid: uuid
@@ -328,6 +331,7 @@ do ->
 			json: true
 			body: stateToSend
 		}
+		.timeout(appConfig.apiTimeout)
 		.spread (response, body) ->
 			if response.statusCode == 200
 				acknowledgedState[device.uuid] = formatTargetAsState(device)
@@ -340,6 +344,7 @@ do ->
 	sendDeleteHook = (device, endpoint) ->
 		uuid = device.uuid
 		request.delAsync("#{endpoint}#{uuid}")
+		.timeout(appConfig.apiTimeout)
 		.spread (response, body) ->
 			if response.statusCode == 200
 				knex('dependentDevice').del().where({ uuid })


### PR DESCRIPTION
Should solve issues when the request hangs after headers have been sent, which seemingly can happen on flaky connections.
Closes #19
Closes #69