### PR TITLE
If there's no entries in deviceConfig table, always create one.

### DIFF
--- a/src/db.coffee
+++ b/src/db.coffee
@@ -28,8 +28,10 @@ knex.init = Promise.all([
 			knex.schema.createTable 'deviceConfig', (t) ->
 				t.json('values')
 				t.json('targetValues')
-			.then ->
-				knex('deviceConfig').insert({ values: '{}', targetValues: '{}' })
+	.then ->
+		knex('deviceConfig').select()
+		.then (deviceConfigs) ->
+			knex('deviceConfig').insert({ values: '{}', targetValues: '{}' }) if deviceConfigs.length == 0
 
 	knex.schema.hasTable('app')
 	.then (exists) ->


### PR DESCRIPTION
Avoids problems if the supervisor is stopped while running the db initialization
(deviceConfig gets created but not populated).

Signed-off-by: Pablo Carranza Velez <pablo@resin.io>
Fixes #353 