### PR TITLE
Base image: remove deprecated -f in docker tag

### DIFF
--- a/base-image/automation/jenkins-build.sh
+++ b/base-image/automation/jenkins-build.sh
@@ -48,7 +48,7 @@ for machine in $MACHINE_LIST; do
 		supervisor-base-builder
 	if [ -f dest/rootfs.tar.gz ]; then
 		docker import dest/rootfs.tar.gz $REPO:$date
-		docker tag -f $REPO:$date $REPO:latest
+		docker tag $REPO:$date $REPO:latest
 		docker push $REPO
 	else
 		echo "rootfs is missing!"


### PR DESCRIPTION
We remove a -f flag used in the base image automation script
when tagging the base image as latest.

Docker 1.10 deprecated the use of -f when doing docker tag,
and it was removed in Docker 1.12. The base image is aways built
in machines with docker > 1.10, and this change allows them to be
built on Docker >= 1.12.

Fixes #361 
Signed-off-by: Pablo Carranza Velez <pablo@resin.io>