### PR TITLE
Use versionist's default configuration

### DIFF
--- a/versionist.conf.js
+++ b/versionist.conf.js
@@ -1,0 +1,1 @@
+module.exports = require('versionist/versionist.conf')


### PR DESCRIPTION
I had forgotten to git add versionist.conf in #364 :S
This will be unnecessary if resin-io/versionist#58 is addressed, but
we want it in the meantime.

Change-Type: patch
Signed-off-by: Pablo Carranza Velez <pablo@resin.io>