### PR TITLE
Use find and sort to make the base image hash more deterministic

### DIFF
--- a/automation/jenkins_build.sh
+++ b/automation/jenkins_build.sh
@@ -3,7 +3,10 @@ set -e
 
 # Jenkins build steps
 export ESCAPED_BRANCH_NAME=$(echo $sourceBranch | sed 's/[^a-z0-9A-Z_.-]/-/g')
-BASE_IMAGE_VERSION=$(tar -c --mtime='1970-01-01' --owner=0 --group=0 -f - base-image | md5sum | awk -F " " '{print $1}')
+git submodule update --init --recursive
+git clean -fxd base-image
+git submodule foreach --recursive git clean -fxd
+BASE_IMAGE_VERSION=$(find base-image -print0 | LC_ALL=C sort -z | tar --null -cf - --no-recursion --mtime=@0 --owner=root --group=root --numeric-owner -T - | md5sum | awk -F " " '{print $1}')
 export BASE_IMAGE_REPO=resin/$ARCH-supervisor-base
 export BASE_IMAGE_TAG=resin/$ARCH-supervisor-base:$BASE_IMAGE_VERSION
 

--- a/base-image/automation/jenkins-build.sh
+++ b/base-image/automation/jenkins-build.sh
@@ -8,9 +8,6 @@ set -o pipefail
 
 JENKINS_PERSISTENT_WORKDIR=${1:-/var/lib/yocto}
 DL_DIR="$JENKINS_PERSISTENT_WORKDIR/shared-downloads"
-
-git submodule update --init --recursive
-rm -rf dest
 mkdir dest
 
 BUILDER_REPO=registry.resinstaging.io/resin/${ARCH}-supervisor-base-builder


### PR DESCRIPTION
We've been using tar directly on the base image folder, and this makes
the file ordering unpredictable between filesystems, so we use find and
sort so that the files are always tarred in the same order, producing the same
hash in different filesystems.

Signed-off-by: Pablo Carranza Velez <pablo@resin.io>