### PR TITLE
[Breaking] Do not bind mount kmod if the host is not Resin OS 1.X

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "lockfile": "^1.0.1",
     "lodash": "^4.16.3",
     "log-timestamp": "^0.1.2",
+    "memoizee": "^0.4.1",
     "mixpanel": "0.0.20",
     "mkdirp": "^0.5.1",
     "network-checker": "~0.0.5",

--- a/src/application.coffee
+++ b/src/application.coffee
@@ -210,13 +210,15 @@ fetch = (app, setDeviceUpdateState = true) ->
 			throw err
 
 shouldMountKmod = (image) ->
-	Promise.using docker.imageRootDirMounted(image), (rootDir) ->
-		utils.getOSVersion(rootDir + '/etc/os-release')
-	.then (version) ->
-		return version? and (version.match(/^Debian/i) or version.match(/^Raspbian/i))
-	.catch (err) ->
-		console.error('Error getting app OS release: ', err)
-		return false
+	device.getOSVersion().then (osVersion) ->
+		return false if not /^Resin OS 1./.test(osVersion)
+		Promise.using docker.imageRootDirMounted(image), (rootDir) ->
+			utils.getOSVersion(rootDir + '/etc/os-release')
+		.then (version) ->
+			return version? and /^(Debian|Raspbian)/i.test(version)
+		.catch (err) ->
+			console.error('Error getting app OS release: ', err)
+			return false
 
 application.start = start = (app) ->
 	volumes = utils.defaultVolumes


### PR DESCRIPTION
Resin OS 2.X removes the use of compressed modules, which was the initial
motivation for us to bind mount kmod into user containers (as Debian distros
don't include support for compressed modules).

This is a breaking change, but we still keep bind mounting on devices that are
on 1.X to ensure we don't break apps currently relying on the feature.

Implementation note: some functions in device.coffee have been refactored to
extract (DRY) a memoization procedure for Promise-returning functions.
`device.getOSVersion()` now also memoizes its result.

Fixes #359
Change-Type: major
Signed-off-by: Pablo Carranza Velez <pablo@resin.io>