### PR TITLE
Bump docker-delta to v1.0.1 to fix deltas on aufs when there's many layers

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "bluebird": "^3.0.0",
     "body-parser": "^1.12.0",
     "buffer-equal-constant-time": "^1.0.1",
-    "docker-delta": "1.0.0",
+    "docker-delta": "1.0.1",
     "docker-progress": "^2.3.1",
     "docker-toolbelt": "^1.3.0",
     "dockerode": "~2.2.9",


### PR DESCRIPTION
Depends on resin-io/node-docker-delta#13 being merged and published.

Fixes #355
Change-Type: patch
Signed-off-by: Pablo Carranza Velez <pablo@resin.io>