### PR TITLE
Increase delta timeouts, and provide nicer message when the delta server times out

### DIFF
--- a/src/application.coffee
+++ b/src/application.coffee
@@ -196,7 +196,9 @@ fetch = (app, setDeviceUpdateState = true) ->
 
 			if conf['RESIN_SUPERVISOR_DELTA'] == '1'
 				logSystemEvent(logTypes.downloadAppDelta, app)
-				dockerUtils.rsyncImageWithProgress(app.imageId, onProgress)
+				requestTimeout = conf['RESIN_SUPERVISOR_DELTA_REQUEST_TIMEOUT'] ? 30 * 60 * 1000
+				totalTimeout = conf['RESIN_SUPERVISOR_DELTA_TOTAL_TIMEOUT'] ? 24 * 60 * 60 * 1000
+				dockerUtils.rsyncImageWithProgress(app.imageId, { requestTimeout, totalTimeout }, onProgress)
 			else
 				logSystemEvent(logTypes.downloadApp, app)
 				dockerUtils.fetchImageWithProgress(app.imageId, onProgress)


### PR DESCRIPTION
Current delta timeouts are too limiting, so we increase the request timeout to 30 minutes which is big enough that
the server will time out first and we can provide a nice message letting the user know we'll retry; and we increase
the total timeout to 24 hours to account for really big deltas over slower connections (the rsync calls will time out anyways
if something else goes wrong, as they have a 5 minute I/O timeout).

The timeouts are now configurable with the RESIN_SUPERVISOR_DELTA_REQUEST_TIMEOUT and RESIN_SUPERVISOR_DELTA_TOTAL_TIMEOUT
configuration variables.

Closes #378 
Change-Type: minor
Signed-off-by: Pablo Carranza Velez <pablo@resin.io>