### PR TITLE
Update versionist to v2.8.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,6 @@
   "devDependencies": {
     "coffee-script": "~1.11.0",
     "resin-lint": "^1.3.1",
-    "versionist": "^2.6.2"
+    "versionist": "^2.8.0"
   }
 }

--- a/versionist.conf.js
+++ b/versionist.conf.js
@@ -1,1 +1,0 @@
-module.exports = require('versionist/versionist.conf')


### PR DESCRIPTION
Also remove versionist.conf.js as it's no longer necessary (versionist now
defaults to its internal versionist.conf) and actually breaks.

Change-Type: patch
Signed-off-by: Pablo Carranza Velez <pablo@resin.io>