### PR TITLE
Issue #381: Set target deviceConfig values from preloaded apps

### DIFF
--- a/src/application.coffee
+++ b/src/application.coffee
@@ -16,6 +16,7 @@ fs = Promise.promisifyAll(require('fs'))
 JSONStream = require 'JSONStream'
 proxyvisor = require './proxyvisor'
 { checkInt } = require './lib/validation'
+deviceConfig = require './device-config'
 
 class UpdatesLockedError extends TypedError
 ImageNotFoundError = (err) ->
@@ -427,11 +428,11 @@ executeSpecialActionsAndHostConfig = (conf, oldConf) ->
 			device.setHostConfig(hostConfigVars, oldHostConfigVars, logSystemMessage)
 
 getAndApplyDeviceConfig = ->
-	device.getConfig()
+	deviceConfig.get()
 	.then ({ values, targetValues }) ->
 		executeSpecialActionsAndHostConfig(targetValues, values)
 		.tap ->
-			device.setConfig({ values: targetValues })
+			deviceConfig.set({ values: targetValues })
 		.then (needsReboot) ->
 			device.reboot() if needsReboot
 
@@ -634,7 +635,7 @@ application.update = update = (force, scheduled = false) ->
 					remoteDeviceConfig = {}
 					_.map remoteAppIds, (appId) ->
 						_.merge(remoteDeviceConfig, JSON.parse(remoteApps[appId].config))
-					device.setConfig({ targetValues: remoteDeviceConfig })
+					deviceConfig.set({ targetValues: remoteDeviceConfig })
 					.then ->
 						getAndApplyDeviceConfig()
 				.catch (err) ->

--- a/src/device-config.coffee
+++ b/src/device-config.coffee
@@ -1,0 +1,15 @@
+knex = require './db'
+
+exports.set = (conf) ->
+	confToUpdate = {}
+	confToUpdate.values = JSON.stringify(conf.values) if conf.values?
+	confToUpdate.targetValues = JSON.stringify(conf.targetValues) if conf.targetValues?
+	knex('deviceConfig').update(confToUpdate)
+
+exports.get = ->
+	knex('deviceConfig').select()
+	.then ([ deviceConfig ]) ->
+		return {
+			values: JSON.parse(deviceConfig.values)
+			targetValues: JSON.parse(deviceConfig.targetValues)
+		}

--- a/src/device.coffee
+++ b/src/device.coffee
@@ -224,16 +224,3 @@ do ->
 
 exports.getOSVersion = memoizePromise ->
 	utils.getOSVersion(config.hostOsVersionPath)
-
-exports.getConfig = ->
-	knex('deviceConfig').select()
-	.then ([ deviceConfig ]) ->
-		return {
-			values: JSON.parse(deviceConfig.values)
-			targetValues: JSON.parse(deviceConfig.targetValues)
-		}
-exports.setConfig = (conf) ->
-	confToUpdate = {}
-	confToUpdate.values = JSON.stringify(conf.values) if conf.values?
-	confToUpdate.targetValues = JSON.stringify(conf.targetValues) if conf.targetValues?
-	knex('deviceConfig').update(confToUpdate)


### PR DESCRIPTION
Also split out deviceConfig set and get to a separate module to avoid circular dependencies.
Closes #381 
Change-Type: patch
Signed-off-by: Pablo Carranza Velez <pablo@resin.io>