### PR TITLE
Issues #389 and #390: Remove /host_run/dbus and /host/var/lib/connman bind mounts for non-ResinOS-1.X devices

### DIFF
--- a/src/device.coffee
+++ b/src/device.coffee
@@ -224,3 +224,8 @@ do ->
 
 exports.getOSVersion = memoizePromise ->
 	utils.getOSVersion(config.hostOsVersionPath)
+
+exports.isResinOSv1 = memoizePromise ->
+	exports.getOSVersion().then (osVersion) ->
+		return true if /^Resin OS 1./.test(osVersion)
+		return false

--- a/src/utils.coffee
+++ b/src/utils.coffee
@@ -242,26 +242,32 @@ exports.getOSVersion = (path) ->
 		console.log('Could not get OS Version: ', err, err.stack)
 		return undefined
 
-exports.defaultVolumes = {
-	'/data': {}
-	'/lib/modules': {}
-	'/lib/firmware': {}
-	'/host/var/lib/connman': {}
-	'/host/run/dbus': {}
-}
+exports.defaultVolumes = (includeV1Volumes) ->
+	volumes = {
+		'/data': {}
+		'/lib/modules': {}
+		'/lib/firmware': {}
+		'/host/run/dbus': {}
+	}
+	if includeV1Volumes
+		volumes['/host/var/lib/connman'] = {}
+		volumes['/host_run/dbus'] = {}
+	return volumes
 
 exports.getDataPath = (identifier) ->
 	return config.dataPath + '/' + identifier
 
-exports.defaultBinds = (dataPath) ->
-	return [
+exports.defaultBinds = (dataPath, includeV1Binds) ->
+	binds = [
 		exports.getDataPath(dataPath) + ':/data'
 		'/lib/modules:/lib/modules'
 		'/lib/firmware:/lib/firmware'
-		'/run/dbus:/host_run/dbus'
 		'/run/dbus:/host/run/dbus'
-		'/var/lib/connman:/host/var/lib/connman'
 	]
+	if includeV1Binds
+		binds.push('/run/dbus:/host_run/dbus')
+		binds.push('/var/lib/connman:/host/var/lib/connman')
+	return binds
 
 exports.validComposeOptions = [
 	'command'


### PR DESCRIPTION
Closes #389 
Closes #390 

On ResinOS 2.X the default mounts should not include the previously deprecated host_run, and there's no connman which makes the connman mount confusing.
This is a breaking change as it is not backwards-compatible on non-ResinOS instances of the supervisor.

Change-Type: major
Signed-off-by: Pablo Carranza Velez <pablo@resin.io>