### PR TITLE
Issue #396: Log when we're rebooting due to a device config change

### DIFF
--- a/src/application.coffee
+++ b/src/application.coffee
@@ -435,7 +435,11 @@ getAndApplyDeviceConfig = ->
 		.tap ->
 			deviceConfig.set({ values: targetValues })
 		.then (needsReboot) ->
-			device.reboot() if needsReboot
+			if needsReboot
+				logSystemMessage('Rebooting', {}, 'Reboot')
+				Promise.delay(1000)
+				.then ->
+					device.reboot()
 
 wrapAsError = (err) ->
 	return err if _.isError(err)


### PR DESCRIPTION
Closes #396 
We also add a 1s delay before rebooting to ensure logs are published.

Change-Type: patch
Signed-off-by: Pablo Carranza Velez <pablo@resin.io>