### PR TITLE
Allow setting the supervisor to a "local mode" which stops apps and prevents cleanup

### DIFF
--- a/src/api.coffee
+++ b/src/api.coffee
@@ -27,6 +27,8 @@ module.exports = (application) ->
 				next()
 			else if headerKey? && bufferEq(new Buffer(headerKey), new Buffer(secret))
 				next()
+			else if application.localMode
+				next()
 			else
 				res.sendStatus(401)
 		.catch (err) ->

--- a/src/application.coffee
+++ b/src/application.coffee
@@ -15,7 +15,7 @@ TypedError = require 'typed-error'
 fs = Promise.promisifyAll(require('fs'))
 JSONStream = require 'JSONStream'
 proxyvisor = require './proxyvisor'
-{ checkInt } = require './lib/validation'
+{ checkInt, checkTruthy } = require './lib/validation'
 deviceConfig = require './device-config'
 
 class UpdatesLockedError extends TypedError
@@ -405,7 +405,7 @@ apiPollInterval = (val) ->
 	application.poll()
 
 setLocalMode = (val) ->
-	mode = (val == '1')
+	mode = checkTruthy(val) ? false
 	Promise.try ->
 		if mode and !application.localMode
 			logSystemMessage('Entering local mode, app will be forcefully stopped', {}, 'Enter local mode')

--- a/src/application.coffee
+++ b/src/application.coffee
@@ -134,9 +134,15 @@ logSystemEvent = (logType, app = {}, error) ->
 
 logSpecialAction = (action, value, success) ->
 	if success
-		msg = "Applied config variable #{action} = #{value}"
+		if !value?
+			msg = "Cleared config variable #{action}"
+		else
+			msg = "Applied config variable #{action} = #{value}"
 	else
-		msg = "Applying config variable #{action} = #{value}"
+		if !value?
+			msg = "Clearing config variable #{action}"
+		else
+			msg = "Applying config variable #{action} = #{value}"
 	logSystemMessage(msg, {}, "Apply special action #{if success then "success" else "in progress"}")
 
 application.kill = kill = (app, { updateDB = true, removeContainer = true } = {}) ->
@@ -435,7 +441,7 @@ executedSpecialActionConfigVars = {}
 
 executeSpecialActionsAndHostConfig = (conf, oldConf) ->
 	Promise.mapSeries specialActionConfigVars, ([ key, specialActionCallback ]) ->
-		if conf[key]? && specialActionCallback?
+		if (conf[key]? or oldConf[key]?) and specialActionCallback?
 			# This makes the Special Action Envs only trigger their functions once.
 			if executedSpecialActionConfigVars[key] != conf[key]
 				logSpecialAction(key, conf[key])

--- a/src/device.coffee
+++ b/src/device.coffee
@@ -230,3 +230,9 @@ exports.isResinOSv1 = memoizePromise ->
 	exports.getOSVersion().then (osVersion) ->
 		return true if /^Resin OS 1./.test(osVersion)
 		return false
+
+exports.getOSVariant = memoizePromise ->
+	utils.getOSReleaseField(config.hostOsVersionPath, 'VARIANT_ID')
+	.catch (err) ->
+		console.error('Failed to get OS variant', err, err.stack)
+		return undefined

--- a/src/device.coffee
+++ b/src/device.coffee
@@ -10,6 +10,7 @@ configPath = '/boot/config.json'
 execAsync = Promise.promisify(require('child_process').exec)
 fs = Promise.promisifyAll(require('fs'))
 bootstrap = require './bootstrap'
+{ checkTruthy } = require './lib/validation'
 
 memoizePromise = _.partial(memoizee, _, promise: true)
 
@@ -78,7 +79,7 @@ exports.setHostConfig = (env, oldEnv, logMessage) ->
 
 setLogToDisplay = (env, oldEnv, logMessage) ->
 	if env['RESIN_HOST_LOG_TO_DISPLAY']?
-		enable = env['RESIN_HOST_LOG_TO_DISPLAY'] != '0'
+		enable = checkTruthy(env['RESIN_HOST_LOG_TO_DISPLAY']) ? true
 		utils.gosuper.postAsync('/v1/set-log-to-display', { json: true, body: Enable: enable })
 		.spread (response, body) ->
 			if response.statusCode != 200

--- a/src/lib/validation.coffee
+++ b/src/lib/validation.coffee
@@ -15,3 +15,10 @@ exports.checkString = (s) ->
 	if !s? or s == 'null' or s == 'undefined' or s == ''
 		return
 	return s
+
+exports.checkTruthy = (v) ->
+	if v == '1' or v == 'true' or v == true or v == 'on'
+		return true
+	if v == '0' or v == 'false' or v == false or v == 'off'
+		return false
+	return

--- a/src/utils.coffee
+++ b/src/utils.coffee
@@ -230,7 +230,7 @@ exports.getKnexApp = (appId, columns) ->
 exports.getKnexApps = (columns) ->
 	knex('app').select(columns)
 
-exports.getOSVersion = (path) ->
+exports.getOSReleaseField = (path, field) ->
 	fs.readFileAsync(path)
 	.then (releaseData) ->
 		lines = releaseData.toString().split('\n')
@@ -239,7 +239,10 @@ exports.getOSVersion = (path) ->
 			[ key, val ] = line.split('=')
 			releaseItems[_.trim(key)] = _.trim(val)
 		# Remove enclosing quotes: http://stackoverflow.com/a/19156197/2549019
-		return releaseItems['PRETTY_NAME'].replace(/^"(.+(?="$))"$/, '$1')
+		return releaseItems[field].replace(/^"(.+(?="$))"$/, '$1')
+
+exports.getOSVersion = (path) ->
+	exports.getOSReleaseField(path, 'PRETTY_NAME')
 	.catch (err) ->
 		console.log('Could not get OS Version: ', err, err.stack)
 		return undefined

--- a/src/utils.coffee
+++ b/src/utils.coffee
@@ -13,6 +13,7 @@ logger = require './lib/logger'
 TypedError = require 'typed-error'
 execAsync = Promise.promisify(require('child_process').exec)
 device = require './device'
+{ checkTruthy } = require './lib/validation'
 
 # Parses package.json and returns resin-supervisor's version
 version = require('../package.json').version
@@ -179,13 +180,14 @@ exports.extendEnvVars = (env, uuid, appId, appName, commit) ->
 
 # Callback function to enable/disable tcp pings
 exports.enableConnectivityCheck = (val) ->
-	bool = val is 'false'
-	disableCheck(bool)
+	enabled = checkTruthy(val) ? true
+	disableCheck(!enabled)
 	console.log("Connectivity check enabled: #{not bool}")
 
 # Callback function to enable/disable logs
 exports.resinLogControl = (val) ->
-	logger.disableLogPublishing(val == 'false')
+	logEnabled = checkTruthy(val) ? true
+	logger.disableLogPublishing(!logEnabled)
 	console.log('Logs enabled: ' + val)
 
 emptyHostRequest = request.defaults({ headers: Host: '' })
@@ -208,7 +210,7 @@ exports.gosuper = gosuper =
 
 # Callback function to enable/disable VPN
 exports.vpnControl = (val) ->
-	enable = val != 'false'
+	enable = checkTruthy(val) ? true
 	gosuper.postAsync('/v1/vpncontrol', { json: true, body: Enable: enable })
 	.spread (response, body) ->
 		if response.statusCode == 202


### PR DESCRIPTION
Connects to https://github.com/resin-io/hq/issues/364
(we now allow any config variable to take different truthy or falsy values)

Connects to https://github.com/resin-io/hq/pull/688

A RESIN_SUPERVISOR_LOCAL_MODE variable is introduced. When this variable is "1", all apps
are stopped and the update cycle stops executing changes other than deviceConfig changes
and the proxyvisor.

Change-Type: minor
Signed-off-by: Pablo Carranza Velez <pablo@resin.io>