### PR TITLE
Issue #402: Ensure that app configs are non-null and valid json objects

### DIFF
--- a/src/db.coffee
+++ b/src/db.coffee
@@ -52,6 +52,9 @@ knex.init = Promise.all([
 				addColumn('app', 'appId', 'string')
 				addColumn('app', 'config', 'json')
 			]
+			.then ->
+				# When updating from older supervisors, config can be null
+				knex('app').update({ config: '{}' }).whereNull('config')
 
 	knex.schema.hasTable('image')
 	.then (exists) ->


### PR DESCRIPTION
Closes #402 
Connects to resin-io/hq#726

This prevents duplicated containers when updating from older supervisors before the config column
was introduced.

Change-Type: patch
Signed-off-by: Pablo Carranza Velez <pablo@resin.io>