### PR TITLE
Issue #410: Cleanup images when the update lock is set

### DIFF
--- a/src/application.coffee
+++ b/src/application.coffee
@@ -700,6 +700,13 @@ application.update = update = (force, scheduled = false) ->
 					utils.setConfig('name', local.name) if local.name != deviceName
 				.then ->
 					parseEnvAndFormatRemoteApps(local.apps, uuid, apiKey)
+			.tap (remoteApps) ->
+				# Before running the updates, try to clean up any images that aren't in use
+				# and will not be used in the target state
+				return if application.localMode
+				dockerUtils.cleanupContainersAndImages(_.map(remoteApps, 'imageId'))
+				.catch (err) ->
+					console.log('Cleanup failed: ', err, err.stack)
 			.then (remoteApps) ->
 				localApps = formatLocalApps(apps)
 				resourcesForUpdate = compareForUpdate(localApps, remoteApps)


### PR DESCRIPTION
We add an extra image/container cleanup before applying updates, allowing any unwanted images to be deleted.
When doing this, we take care not to delete images that will be used when the target state is applied.

This prevents the problem of stale images being stored while the update lock is set, potentially
leaving the device out of space.

Running the cleanup *before* applying the update ensures that only one target image is downloaded: if a stale one
had been downloaded previously, it will be deleted before starting the update for the new one. This can have a slight
impact on delta performance, since the delta is potentially done from an older (and more different) version of the app,
but can have a big impact on storage usage, as not doing this would duplicate the required free storage space when
the update lock is set.

Closes #410 
Change-Type: patch
Signed-off-by: Pablo Carranza Velez <pablo@resin.io>