### PR TITLE
Issue #420: Avoid supervisor crash without connection by properly memoizing promise-returning functions

### DIFF
--- a/src/device.coffee
+++ b/src/device.coffee
@@ -13,7 +13,8 @@ bootstrap = require './bootstrap'
 { checkTruthy } = require './lib/validation'
 osRelease = require './lib/os-release'
 
-memoizePromise = _.partial(memoizee, _, promise: true)
+# If we don't use promise: 'then', exceptions will crash the program
+memoizePromise = _.partial(memoizee, _, promise: 'then')
 
 
 exports.getID = memoizePromise ->


### PR DESCRIPTION
Closes #420 

device.getID caused a fatal error when connection was down, as the memoization with `promise: true` throws
synchronously. Changing memoizee to use `promise: 'then'` makes the memoization work as expected.

Change-Type: patch
Signed-off-by: Pablo Carranza Velez <pablo@resin.io>