### PR TITLE
Make deltas resilient to slow network and/or truncated delta files

### DIFF
--- a/base-image/meta-resin-supervisor/recipes-devtools/rsync/rsync/0001-batch-exit-if-we-reach-EOF-during-processing.patch
+++ b/base-image/meta-resin-supervisor/recipes-devtools/rsync/rsync/0001-batch-exit-if-we-reach-EOF-during-processing.patch
@@ -1,0 +1,31 @@
+From 806089f11a484d035df76717638cfb1aa8124766 Mon Sep 17 00:00:00 2001
+From: Petros Angelatos <petrosagg@gmail.com>
+Date: Sat, 22 Apr 2017 14:30:32 +0100
+Subject: [PATCH] batch: exit if we reach EOF during processing
+
+rsync will hang forever under certain conditions if its input is
+truncated. This ensures that if we don't read all the expected data the
+process will immediately exit.
+
+Signed-off-by: Petros Angelatos <petrosagg@gmail.com>
+---
+ io.c | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/io.c b/io.c
+index ef70d677..add99410 100644
+--- a/io.c
++++ b/io.c
+@@ -620,6 +620,9 @@ static char *perform_io(size_t needed, int flags)
+ 		case PIO_NEED_INPUT:
+ 			if (iobuf.in.len >= needed)
+ 				goto double_break;
++			if (am_receiver && batch_fd < 0) {
++				iobuf.in_fd = -2;
++			}
+ 			break;
+ 		case PIO_NEED_OUTROOM:
+ 			/* Note that iobuf.out_empty_len doesn't factor into this check
+-- 
+2.12.2
+

--- a/base-image/meta-resin-supervisor/recipes-devtools/rsync/rsync_%.bbappend
+++ b/base-image/meta-resin-supervisor/recipes-devtools/rsync/rsync_%.bbappend
@@ -1,4 +1,5 @@
 FILESEXTRAPATHS_append := ":${THISDIR}/${PN}"
 SRC_URI_append = " \
     file://rsync-3.1.2-max-128-basis-dirs.patch \
+    file://0001-batch-exit-if-we-reach-EOF-during-processing.patch \
     "

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "bluebird": "^3.5.0",
     "body-parser": "^1.12.0",
     "buffer-equal-constant-time": "^1.0.1",
-    "docker-delta": "1.0.1",
+    "docker-delta": "^1.0.2",
     "docker-progress": "^2.5.0",
     "docker-toolbelt": "^1.3.0",
     "dockerode": "~2.2.9",


### PR DESCRIPTION
This fixes the issue where the delta file is downloaded very slowly and causes rsync to timeout