### PR TITLE
Only delete the provisioning key if the supervisor is running on an OS that supports using the deviceApiKey

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,8 @@
     "resin-register-device": "^3.0.0",
     "rimraf": "^2.5.4",
     "rwlock": "^5.0.0",
+    "semver": "^5.3.0",
+    "semver-regex": "^1.0.0",
     "sqlite3": "^3.1.0",
     "typed-error": "~0.1.0",
     "yamljs": "^0.2.7"


### PR DESCRIPTION

This avoids problems when updating the supervisor on an older OS, where the VPN and other
host services still require config.json to have an apiKey field to authenticate.

Change-Type: patch
Signed-off-by: Pablo Carranza Velez <pablo@resin.io>