### PR TITLE
.dockerignore: Ignore the .git directory in submodules

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,5 @@
 .dockerignore
-.git
+**/.git
 node_modules
 .editorconfig
 tools


### PR DESCRIPTION
I'm seeing that docker build cache is getting invalidated in some cases, and the only
possible culprit I can think of is the .git directory in the base image submodules.

This change adds a wildcard in the dockerignore file to ignore .git in all directories, not just the root.

Change-Type: patch
Signed-off-by: Pablo Carranza Velez <pablo@resin.io>