### PR TITLE
Multicontainer logger

### DIFF
--- a/src/compose/service-manager.coffee
+++ b/src/compose/service-manager.coffee
@@ -139,7 +139,7 @@ module.exports = class ServiceManager extends EventEmitter
 				.then =>
 					@logger.logSystemEvent(logTypes.startServiceError, { service, error: err })
 			.then =>
-				@logger.attach(@docker, container.id, service.serviceId)
+				@logger.attach(@docker, container.id, service)
 		.tap =>
 			if alreadyStarted
 				@logger.logSystemEvent(logTypes.startServiceNoop, { service })
@@ -253,7 +253,7 @@ module.exports = class ServiceManager extends EventEmitter
 								@emit('change')
 								delete @containerHasDied[data.id]
 								@logger.logSystemEvent(logTypes.serviceRestart, { service })
-								@logger.attach(@docker, data.id, service.serviceId)
+								@logger.attach(@docker, data.id, service)
 					.catch (err) ->
 						console.error('Error on docker event:', err, err.stack)
 					return
@@ -278,4 +278,4 @@ module.exports = class ServiceManager extends EventEmitter
 		@getAll()
 		.map (service) =>
 			@logger.logSystemEvent(logTypes.startServiceNoop, { service })
-			@logger.attach(@docker, service.containerId, service.serviceId)
+			@logger.attach(@docker, service.containerId, service)

--- a/src/config.coffee
+++ b/src/config.coffee
@@ -143,6 +143,7 @@ module.exports = class Config extends EventEmitter
 			deltaRetryInterval: { source: 'db', mutable: true, default: '10000' }
 			lockOverride: { source: 'db', mutable: true, default: 'false' }
 			legacyAppsPresent: { source: 'db', mutable: true, default: 'false' }
+			nativeLogger: { source: 'db', mutable: true, default: 'false' }
 		}
 
 		@configJsonCache = {}

--- a/src/device-config.coffee
+++ b/src/device-config.coffee
@@ -48,6 +48,7 @@ module.exports = class DeviceConfig
 			deltaRetryCount: { envVarName: 'RESIN_SUPERVISOR_DELTA_RETRY_COUNT', varType: 'int', defaultValue: '30' }
 			deltaRetryInterval: { envVarName: 'RESIN_SUPERVISOR_DELTA_RETRY_INTERVAL', varType: 'int', defaultValue: '10000' }
 			lockOverride: { envVarName: 'RESIN_SUPERVISOR_OVERRIDE_LOCK', varType: 'bool', defaultValue: 'false' }
+			nativeLogger: { envVarName: 'RESIN_SUPERVISOR_NATIVE_LOGGER', varType: 'bool', defaultValue: 'false' }
 		}
 		@validKeys = [ 'RESIN_HOST_LOG_TO_DISPLAY', 'RESIN_SUPERVISOR_VPN_CONTROL', 'RESIN_OVERRIDE_LOCK' ].concat(_.map(@configKeys, 'envVarName'))
 		@actionExecutors = {

--- a/src/device-state.coffee
+++ b/src/device-state.coffee
@@ -15,7 +15,6 @@ updateLock = require './lib/update-lock'
 { singleToMulticontainerApp } = './lib/migration'
 
 DeviceConfig = require './device-config'
-Logger = require './logger'
 ApplicationManager = require './application-manager'
 
 validateLocalState = (state) ->
@@ -114,8 +113,7 @@ createDeviceStateRouter = (deviceState) ->
 	return router
 
 module.exports = class DeviceState extends EventEmitter
-	constructor: ({ @db, @config, @eventTracker }) ->
-		@logger = new Logger({ @eventTracker })
+	constructor: ({ @db, @config, @eventTracker, @logger }) ->
 		@deviceConfig = new DeviceConfig({ @db, @config, @logger })
 		@applications = new ApplicationManager({ @config, @logger, @db, @eventTracker, deviceState: this })
 		@on 'error', (err) ->
@@ -161,25 +159,20 @@ module.exports = class DeviceState extends EventEmitter
 			@config.set({ legacyAppsPresent: 'false' })
 
 	init: ->
+		@config.on 'change', (changedConfig) =>
+			if changedConfig.loggingEnabled?
+				@logger.enable(changedConfig.loggingEnabled)
+			if changedConfig.nativeLogger?
+				@logger.switchBackend(changedConfig.nativeLogger)
+			if changedConfig.apiSecret?
+				@reportCurrentState(api_secret: changedConfig.apiSecret)
+
 		@config.getMany([
-			'logsChannelSecret', 'pubnub', 'offlineMode', 'loggingEnabled', 'initialConfigSaved',
-			'listenPort', 'apiSecret', 'osVersion', 'osVariant', 'version', 'provisioned',
-			'resinApiEndpoint', 'connectivityCheckEnabled', 'legacyAppsPresent'
+			'initialConfigSaved', 'listenPort', 'apiSecret', 'osVersion', 'osVariant', 'logsChannelSecret',
+			'version', 'provisioned', 'resinApiEndpoint', 'connectivityCheckEnabled', 'legacyAppsPresent'
 		])
 		.then (conf) =>
-			@logger.init({
-				pubnub: conf.pubnub
-				channel: "device-#{conf.logsChannelSecret}-logs"
-				offlineMode: conf.offlineMode
-				enable: conf.loggingEnabled
-			})
-			.then =>
-				@config.on 'change', (changedConfig) =>
-					if changedConfig.loggingEnabled?
-						@logger.enable(changedConfig.loggingEnabled)
-					if changedConfig.apiSecret?
-						@reportCurrentState(api_secret: changedConfig.apiSecret)
-			.then =>
+			Promise.try =>
 				if validation.checkTruthy(conf.legacyAppsPresent)
 					@normaliseLegacy()
 			.then =>

--- a/src/proxyvisor.coffee
+++ b/src/proxyvisor.coffee
@@ -137,7 +137,7 @@ createProxyvisorRouter = (proxyvisor) ->
 		.then ([ device ]) ->
 			return res.status(404).send('Device not found') if !device?
 			return res.status(410).send('Device deleted') if device.markedForDeletion
-			proxyvisor.logger.log(m, { channel: "device-#{device.logs_channel}-logs" })
+			proxyvisor.logger.logDependent(m, { uuid, channel: "device-#{device.logs_channel}-logs" })
 			res.status(202).send('OK')
 		.catch (err) ->
 			console.error("Error on #{req.method} #{url.parse(req.url).pathname}", err, err.stack)

--- a/src/supervisor.coffee
+++ b/src/supervisor.coffee
@@ -6,6 +6,7 @@ Config = require './config'
 APIBinder = require './api-binder'
 DeviceState = require './device-state'
 SupervisorAPI = require './supervisor-api'
+Logger = require './logger'
 
 constants = require './lib/constants'
 
@@ -17,6 +18,10 @@ startupConfigFields = [
 	'offlineMode'
 	'mixpanelToken'
 	'mixpanelHost'
+	'logsChannelSecret'
+	'pubnub'
+	'loggingEnabled'
+	'nativeLogger'
 ]
 
 module.exports = class Supervisor extends EventEmitter
@@ -24,7 +29,8 @@ module.exports = class Supervisor extends EventEmitter
 		@db = new DB()
 		@config = new Config({ @db })
 		@eventTracker = new EventTracker()
-		@deviceState = new DeviceState({ @config, @db, @eventTracker })
+		@logger = new Logger({ @eventTracker })
+		@deviceState = new DeviceState({ @config, @db, @eventTracker, @logger })
 		@apiBinder = new APIBinder({ @config, @db, @deviceState, @eventTracker })
 
 		# FIXME: rearchitect proxyvisor to avoid this circular dependency
@@ -42,6 +48,18 @@ module.exports = class Supervisor extends EventEmitter
 			@eventTracker.init(conf)
 			.then =>
 				@eventTracker.track('Supervisor start')
+			.then =>
+				@apiBinder.initClient()
+			.then =>
+				@logger.init({
+					nativeLogger: conf.nativeLogger
+					apiBinder: @apiBinder
+					pubnub: conf.pubnub
+					channel: "device-#{conf.logsChannelSecret}-logs"
+					offlineMode: conf.offlineMode
+					enable: conf.loggingEnabled
+				})
+			.then =>
 				@deviceState.init()
 			.then =>
 				# initialize API
@@ -49,4 +67,4 @@ module.exports = class Supervisor extends EventEmitter
 				@api.listen(constants.allowedInterfaces, conf.listenPort, conf.apiTimeout)
 				@deviceState.on('shutdown', => @api.stop())
 			.then =>
-				@apiBinder.init() # this will first try to provision if it's a new device
+				@apiBinder.start() # this will first try to provision if it's a new device


### PR DESCRIPTION
Work in progress to implement logging to the Resin API on the multicontainer supervisor.

During an experimental phase, logs can be switched between Pubnub and Resin with a config variable.

Logs can have an imageId attached, which the resin API uses to infer the image_install that each log relates to. Logs sent to Pubnub, instead, just have a `c` to identify the serviceId that they relate to.

(Still untested)