### PR TITLE
Fix state endpoint payload

### DIFF
--- a/src/application-manager.coffee
+++ b/src/application-manager.coffee
@@ -400,7 +400,7 @@ module.exports = class ApplicationManager extends EventEmitter
 						else
 							console.log('Ignoring legacy dependent image', image)
 
-				obj = { local: apps, dependent }
+				obj = local: { apps, dependent }
 				if releaseId and targetApps[0]?.releaseId == releaseId
 					obj.commit = targetApps[0].commit
 				return obj


### PR DESCRIPTION
The data previously sent to the API was in the form of
```
obj = {
  local: apps,
  dependent
};
```

where as according to the API
( https://github.com/resin-io/resin-api/blob/multicontainer2/src/routes/devices.coffee#L964
)
it should be in the form:

```
obj = {
  local: {apps, dependent}
};
```

This also fixes this sentry error https://sentry.io/resinio/api-multi/issues/443300912/events/13511247699/