### PR TITLE
Fix the way commands and entrypoints in string form are parsed

### DIFF
--- a/src/compose/service.coffee
+++ b/src/compose/service.coffee
@@ -28,17 +28,29 @@ createRestartPolicy = (name) ->
 		name = 'always'
 	return { Name: name, MaximumRetryCount: 0 }
 
+processCommandStr = (s) ->
+	# Escape dollars
+	s.replace(/(\$)/g, '\\$1')
+
+processCommandParsedArrayElement = (arg) ->
+	if _.isObject(arg)
+		if arg.op == 'glob'
+			return arg.pattern
+		return arg.op
+	return arg
+
+ensureCommandIsArray = (s) ->
+	if _.isString(s)
+		s = _.map(parseCommand(processCommandStr(s)), processCommandParsedArrayElement)
+	return s
+
 getCommand = (service, imageInfo) ->
 	cmd = service.command ? imageInfo?.Config?.Cmd ? null
-	if _.isString(cmd)
-		cmd = parseCommand(cmd)
-	return cmd
+	return ensureCommandIsArray(cmd)
 
 getEntrypoint = (service, imageInfo) ->
 	entry = service.entrypoint ? imageInfo?.Config?.Entrypoint ? null
-	if _.isString(entry)
-		entry = parseCommand(entry)
-	return entry
+	return ensureCommandIsArray(entry)
 
 getStopSignal = (service, imageInfo) ->
 	sig = service.stopSignal ? imageInfo?.Config?.StopSignal ? null


### PR DESCRIPTION

Turns out shell-quote's parse function also replaces environment variables, which we don't want in this case. So we escape dollar signs
before calling shell-quote's parse function.

Also shell-quote takes some characters like `>` and globs and returns an object - so we return those objects to string form.

This should still be simpler/better than writing our own shlex.split, I hope...

Change-Type: patch
Signed-off-by: Pablo Carranza Velez <pablo@resin.io>
