### PR TITLE
Add mocha to enable unit testing

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,3 +10,6 @@ insert_final_newline = true
 
 [*.md]
 trim_trailing_whitespace = false
+
+[*.json]
+indent_style = space

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "start": "./entry.sh",
     "build": "webpack",
     "lint": "resin-lint src/",
-    "versionist": "versionist"
+    "versionist": "versionist",
+    "test": "mocha -r coffee-script/register test/**/*"
   },
   "dependencies": {
     "mkfifo": "^0.1.5",
@@ -26,6 +27,7 @@
     "bluebird": "^3.5.0",
     "body-parser": "^1.12.0",
     "buffer-equal-constant-time": "^1.0.1",
+    "chai": "^4.1.2",
     "coffee-loader": "^0.7.3",
     "coffee-script": "~1.11.0",
     "copy-webpack-plugin": "^4.2.3",
@@ -44,6 +46,7 @@
     "memoizee": "^0.4.1",
     "mixpanel": "0.0.20",
     "mkdirp": "^0.5.1",
+    "mocha": "^5.0.5",
     "network-checker": "~0.0.5",
     "node-loader": "^0.6.0",
     "null-loader": "^0.1.1",

--- a/test/compose/service.spec.coffee
+++ b/test/compose/service.spec.coffee
@@ -1,0 +1,42 @@
+{ expect } = require 'chai'
+ComposeService = require '../../src/compose/service'
+
+describe 'compose/service.cofee', ->
+	describe 'parseMemoryNumber()', ->
+		makeComposeServiceWithLimit = (memLimit) ->
+			console.log('MAKING SERVICE WITH LIMIT', memLimit)
+			new ComposeService(
+				appId: 123456
+				serviceId: 123456
+				serviceName: 'foobar'
+				memLimit: memLimit
+			)
+
+		it 'should correctly parse memory number strings without a unit', ->
+			expect(makeComposeServiceWithLimit('64').memLimit).to.equal(64)
+
+		it 'should correctly parse memory number strings that use a byte unit', ->
+			expect(makeComposeServiceWithLimit('64b').memLimit).to.equal(64)
+			expect(makeComposeServiceWithLimit('64B').memLimit).to.equal(64)
+
+		it 'should correctly parse memory number strings that use a kilobyte unit', ->
+			expect(makeComposeServiceWithLimit('64k').memLimit).to.equal(65536)
+			expect(makeComposeServiceWithLimit('64K').memLimit).to.equal(65536)
+
+			expect(makeComposeServiceWithLimit('64kb').memLimit).to.equal(65536)
+			expect(makeComposeServiceWithLimit('64Kb').memLimit).to.equal(65536)
+
+		it 'should correctly parse memory number strings that use a megabyte unit', ->
+			expect(makeComposeServiceWithLimit('64m').memLimit).to.equal(67108864)
+			expect(makeComposeServiceWithLimit('64M').memLimit).to.equal(67108864)
+
+			expect(makeComposeServiceWithLimit('64mb').memLimit).to.equal(67108864)
+			expect(makeComposeServiceWithLimit('64Mb').memLimit).to.equal(67108864)
+
+		it 'should correctly parse memory number strings that use a gigabyte unit', ->
+			expect(makeComposeServiceWithLimit('64g').memLimit).to.equal(68719476736)
+			expect(makeComposeServiceWithLimit('64G').memLimit).to.equal(68719476736)
+
+			expect(makeComposeServiceWithLimit('64gb').memLimit).to.equal(68719476736)
+			expect(makeComposeServiceWithLimit('64Gb').memLimit).to.equal(68719476736)
+


### PR DESCRIPTION
Implements a simple test for `parseMemoryNumber`

change-type: minor

@CameronDiver You'll notice that the implementation is currently broken if you don't specify a unit