### PR TITLE
Push version-tagged images from the 6.x branch

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -37,7 +37,7 @@ defaults: &defaults
         no_output_timeout: 10800
         command: |
             VERSION_TAG=v$(jq .version package.json | sed 's/"//g')
-            if [ "${CIRCLE_BRANCH}" = "master" ]; then
+            if [ "${CIRCLE_BRANCH}" = "master" ] || [ "${CIRCLE_BRANCH}" = "6.x" ]; then
               export EXTRA_TAG=$VERSION_TAG
             fi
             echo "Starting build.sh"


### PR DESCRIPTION
This will allow us to push critical fixes for devices that are not ready to support the 7.x supervisor line.

Change-Type: patch
Signed-off-by: Pablo Carranza Velez <pablo@resin.io>