### PR TITLE
WIP: Add /v2/device/target-state endpoints to allow setting a target state…

### DIFF
--- a/src/application-manager.coffee
+++ b/src/application-manager.coffee
@@ -782,10 +782,6 @@ module.exports = class ApplicationManager extends EventEmitter
 		Promise.try =>
 			delta = checkTruthy(delta)
 			if checkTruthy(localMode)
-				target = _.cloneDeep(target)
-				target.local.apps = _.mapValues target.local.apps, (app) ->
-					app.services = []
-					return app
 				ignoreImages = true
 			currentByAppId = current.local.apps ? {}
 			targetByAppId = target.local.apps ? {}


### PR DESCRIPTION
…, and make the API listen on all interfaces, when the device is in local mode

Change-Type: minor
Signed-off-by: Pablo Carranza Velez <pablo@resin.io>

This is an initial -untested- attempt, and we still need to decide on what the interface looks like

Connects-to: https://github.com/resin-io/hq/issues/1285