### PR TITLE
fix: Dont bind service class methods in declaration

### DIFF
--- a/src/compose/service.coffee
+++ b/src/compose/service.coffee
@@ -565,7 +565,7 @@ module.exports = class Service
 				volumes[vol] = {}
 		return { binds, volumes }
 
-	toContainerConfig: =>
+	toContainerConfig: ->
 		{ binds, volumes } = @getBindsAndVolumes()
 		tmpfs = {}
 		for dir in @tmpfs
@@ -651,7 +651,7 @@ module.exports = class Service
 		return conf
 
 	# TODO: when we support network configuration properly, return endpointConfig: conf
-	extraNetworksToJoin: =>
+	extraNetworksToJoin: ->
 		_.map _.pickBy(@networks, (conf, net) => net != @networkMode), (conf, net) ->
 			return { name: net, endpointConfig: {} }
 


### PR DESCRIPTION
This was causing a bug where the applications were cloned when
restarting all of them. These clones did not carry over the binds, so
when starting the containers back up, two different versions of `this`
were being used.

Change-type: patch
Closes: #736
Signed-off-by: Cameron Diver <cameron@resin.io>