### PR TITLE
fix: Use throttle not debounce when ensuring we don't spam mixpanel

### DIFF
--- a/src/event-tracker.ts
+++ b/src/event-tracker.ts
@@ -86,12 +86,12 @@ export class EventTracker {
 		}
 
 		properties = this.assignDefaultProperties(properties);
-		this.debouncedLogger(event)(properties);
+		this.throttleddLogger(event)(properties);
 	}
 
-	private debouncedLogger = memoizee((event: string) => {
+	private throttleddLogger = memoizee((event: string) => {
 		// Call this function at maximum once every minute
-		return _.debounce((properties) => {
+		return _.throttle((properties) => {
 			this.client.track(event, properties);
 		}, eventDebounceTime, { leading: true });
 	}, { primitive: true });


### PR DESCRIPTION
Debounce will mean that in certain cases, the events will never be sent,
whereas with throttle we can be sure that it will be sent a minimum
amount per time slice.

Change-type: patch
Signed-off-by: Cameron Diver <cameron@resin.io>