### PR TITLE
lib/errors: Improve typings by extending Error class for predicates

### DIFF
--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -3,15 +3,25 @@ import TypedError = require('typed-error');
 
 import { checkInt } from './validation';
 
-export function NotFoundError(err: { statusCode?: string }): boolean {
+// To keep the bluebird typings happy, we need to accept
+// an error, and in this case, it would also contain a status code
+interface StatusCodeError extends Error {
+	statusCode?: string;
+}
+
+interface CodedSysError extends Error {
+	code?: string;
+}
+
+export function NotFoundError(err: StatusCodeError): boolean {
 	return checkInt(err.statusCode) === 404;
 }
 
-export function ENOENT(err: { code: string, [key: string]: any }): boolean {
+export function ENOENT(err: CodedSysError): boolean {
 	return err.code === 'ENOENT';
 }
 
-export function EEXIST(err: { code: string, [key: string]: any }): boolean {
+export function EEXIST(err: CodedSysError): boolean {
 	return err.code === 'EEXIST';
 }
 


### PR DESCRIPTION
When using the predicate functions in bluebird `.catch`es from
typescript, the compiler would complain that the predicates do not
accept a function which takes an error. Because these are specific
errors, I've extended the base `Error` class, and added the extra fields
we expect.

Change-type: patch
Signed-off-by: Cameron Diver <cameron@resin.io>