### PR TITLE
backend: Remove a few blacklisted config.txt options

### DIFF
--- a/src/config/backend.ts
+++ b/src/config/backend.ts
@@ -88,11 +88,7 @@ export class RPiConfigBackend extends DeviceConfigBackend {
 		'ramfsaddr',
 		'initramfs',
 		'device_tree_address',
-		'init_uart_baud',
-		'init_uart_clock',
 		'init_emmc_clock',
-		'boot_delay',
-		'boot_delay_ms',
 		'avoid_safe_mode',
 	];
 


### PR DESCRIPTION
These options were discussed in an arch call and the conclusion was
that they don't need to be in the blacklist.

Change-type: patch
Changelog-entry: Remove a few blacklisted config.txt options
Signed-off-by: Zubair Lutfullah Kakakhel <zubair@resin.io>