### PR TITLE
Replace io.resin labels (and their env vars) with io.balena equivalents

### DIFF
--- a/src/application-manager.coffee
+++ b/src/application-manager.coffee
@@ -96,7 +96,7 @@ module.exports = class ApplicationManager extends EventEmitter
 				# Only called for dead containers, so no need to take locks or anything
 				@services.remove(step.current)
 			updateMetadata: (step, { force = false, skipLock = false } = {}) =>
-				skipLock or= checkTruthy(step.current.config.labels['io.resin.legacy-container'])
+				skipLock or= checkTruthy(step.current.config.labels['io.balena.legacy-container'])
 				@_lockingIfNecessary step.current.appId, { force, skipLock: skipLock or step.options?.skipLock }, =>
 					@services.updateMetadata(step.current, step.target)
 			restart: (step, { force = false, skipLock = false } = {}) =>
@@ -591,11 +591,11 @@ module.exports = class ApplicationManager extends EventEmitter
 			# Either this is a new service, or the current one has already been killed
 			return @_fetchOrStartStep(current, target, needsDownload, dependenciesMetForStart)
 		else
-			strategy = checkString(target.config.labels['io.resin.update.strategy'])
+			strategy = checkString(target.config.labels['io.balena.update.strategy'])
 			validStrategies = [ 'download-then-kill', 'kill-then-download', 'delete-then-download', 'hand-over' ]
 			if !_.includes(validStrategies, strategy)
 				strategy = 'download-then-kill'
-			timeout = checkInt(target.config.labels['io.resin.update.handover-timeout'])
+			timeout = checkInt(target.config.labels['io.balena.update.handover-timeout'])
 			return @_strategySteps[strategy](current, target, needsDownload, dependenciesMetForStart, dependenciesMetForKill, needsSpecialKill, timeout)
 
 	_nextStepsForAppUpdate: (currentApp, targetApp, localMode, availableImages = [], downloading = []) =>
@@ -608,12 +608,12 @@ module.exports = class ApplicationManager extends EventEmitter
 		currentApp ?= emptyApp
 		if currentApp.services?.length == 1 and targetApp.services?.length == 1 and
 			targetApp.services[0].serviceName == currentApp.services[0].serviceName and
-			checkTruthy(currentApp.services[0].config.labels['io.resin.legacy-container'])
+			checkTruthy(currentApp.services[0].config.labels['io.balena.legacy-container'])
 				# This is a legacy preloaded app or container, so we didn't have things like serviceId.
 				# We hack a few things to avoid an unnecessary restart of the preloaded app
 				# (but ensuring it gets updated if it actually changed)
-				targetApp.services[0].config.labels['io.resin.legacy-container'] = currentApp.services[0].labels['io.resin.legacy-container']
-				targetApp.services[0].config.labels['io.resin.service-id'] = currentApp.services[0].labels['io.resin.service-id']
+				targetApp.services[0].config.labels['io.balena.legacy-container'] = currentApp.services[0].labels['io.balena.legacy-container']
+				targetApp.services[0].config.labels['io.balena.service-id'] = currentApp.services[0].labels['io.balena.service-id']
 				targetApp.services[0].serviceId = currentApp.services[0].serviceId
 
 		appId = targetApp.appId ? currentApp.appId

--- a/src/compose/images.coffee
+++ b/src/compose/images.coffee
@@ -313,4 +313,9 @@ module.exports = class Images extends EventEmitter
 	isSameImage: @isSameImage
 
 	_getLocalModeImages: =>
-		@docker.listImages(filters: label: [ 'io.resin.local.image=1' ])
+		Promise.join(
+			@docker.listImages(filters: label: [ 'io.resin.local.image=1' ])
+			@docker.listImages(filters: label: [ 'io.balena.local.image=1' ])
+			(legacyImages, currentImages) ->
+				_.unionBy(legacyImages, currentImages, 'Id')
+		)

--- a/src/compose/network.ts
+++ b/src/compose/network.ts
@@ -9,6 +9,7 @@ import {
 import logTypes = require('../lib/log-types');
 import { checkInt } from '../lib/validation';
 import { Logger } from '../logger';
+import * as ComposeUtils from './utils';
 
 import {
 	DockerIPAMConfig,
@@ -83,7 +84,7 @@ export class Network {
 			},
 			enableIPv6: network.EnableIPv6,
 			internal: network.Internal,
-			labels: _.omit(network.Labels, [ 'io.resin.supervised' ]),
+			labels: _.omit(ComposeUtils.normalizeLabels(network.Labels), [ 'io.balena.supervised' ]),
 			options: network.Options,
 		};
 
@@ -125,6 +126,7 @@ export class Network {
 			labels: { },
 			options: { },
 		});
+		net.config.labels = ComposeUtils.normalizeLabels(net.config.labels);
 
 		return net;
 	}
@@ -177,7 +179,7 @@ export class Network {
 			EnableIPv6: this.config.enableIPv6,
 			Internal: this.config.internal,
 			Labels: _.merge({}, {
-				'io.resin.supervised': 'true',
+				'io.balena.supervised': 'true',
 			}, this.config.labels),
 		};
 	}

--- a/src/compose/service-manager.coffee
+++ b/src/compose/service-manager.coffee
@@ -113,6 +113,7 @@ module.exports = class ServiceManager extends EventEmitter
 
 				# TODO: Don't mutate service like this, use an interface
 				service.config.environment['RESIN_DEVICE_NAME_AT_INIT'] = deviceName
+				service.config.environment['BALENA_DEVICE_NAME_AT_INIT'] = deviceName
 
 				@logger.logSystemEvent(logTypes.installService, { service })
 				@reportNewStatus(mockContainerId, service, 'Installing')

--- a/src/compose/service-manager.coffee
+++ b/src/compose/service-manager.coffee
@@ -100,8 +100,6 @@ module.exports = class ServiceManager extends EventEmitter
 		.then (existingService) =>
 			return @docker.getContainer(existingService.containerId)
 		.catch NotFoundError, =>
-			conf = service.toDockerContainer()
-			nets = service.extraNetworksToJoin()
 
 			@config.get('name')
 			.then (deviceName) =>
@@ -111,9 +109,8 @@ module.exports = class ServiceManager extends EventEmitter
 						'Please fix the device name.'
 					)
 
-				# TODO: Don't mutate service like this, use an interface
-				service.config.environment['RESIN_DEVICE_NAME_AT_INIT'] = deviceName
-				service.config.environment['BALENA_DEVICE_NAME_AT_INIT'] = deviceName
+				conf = service.toDockerContainer({ deviceName })
+				nets = service.extraNetworksToJoin()
 
 				@logger.logSystemEvent(logTypes.installService, { service })
 				@reportNewStatus(mockContainerId, service, 'Installing')

--- a/src/compose/service-manager.coffee
+++ b/src/compose/service-manager.coffee
@@ -88,7 +88,7 @@ module.exports = class ServiceManager extends EventEmitter
 			@logger.logSystemEvent(logTypes.removeDeadServiceError, { service, error: err })
 
 	getAllByAppId: (appId) =>
-		@getAll("io.resin.app-id=#{appId}")
+		@getAll("app-id=#{appId}")
 
 	stopAllByAppId: (appId) =>
 		Promise.map @getAllByAppId(appId), (service) =>
@@ -174,10 +174,20 @@ module.exports = class ServiceManager extends EventEmitter
 		.finally =>
 			@reportChange(containerId)
 
+	_listWithBothLabels: (labelList) =>
+		listWithPrefix = (prefix) =>
+			@docker.listContainers({ all: true, filters: label: _.map(labelList, (v) -> prefix + v) })
+		Promise.join(
+			listWithPrefix('io.resin.')
+			listWithPrefix('io.balena.')
+			(legacyContainers, currentContainers) ->
+				_.unionBy(legacyContainers, currentContainers, 'Id')
+		)
+
 	# Gets all existing containers that correspond to apps
 	getAll: (extraLabelFilters = []) =>
-		filters = label: [ 'io.resin.supervised' ].concat(extraLabelFilters)
-		@docker.listContainers({ all: true, filters })
+		filterLabels = [ 'supervised' ].concat(extraLabelFilters)
+		@_listWithBothLabels(filterLabels)
 		.mapSeries (container) =>
 			@docker.getContainer(container.Id).inspect()
 			.then(Service.fromDockerContainer)
@@ -190,7 +200,7 @@ module.exports = class ServiceManager extends EventEmitter
 
 	# Returns the first container matching a service definition
 	get: (service) =>
-		@getAll("io.resin.service-id=#{service.serviceId}")
+		@getAll("service-id=#{service.serviceId}")
 		.filter((currentService) -> currentService.isEqualConfig(service))
 		.then (services) ->
 			if services.length == 0
@@ -218,7 +228,7 @@ module.exports = class ServiceManager extends EventEmitter
 	getByDockerContainerId: (containerId) =>
 		@docker.getContainer(containerId).inspect()
 		.then (container) ->
-			if !container.Config.Labels['io.resin.supervised']?
+			if !(container.Config.Labels['io.balena.supervised']? or container.Config.Labels['io.resin.supervised']?)
 				return null
 			return Service.fromDockerContainer(container)
 
@@ -267,7 +277,7 @@ module.exports = class ServiceManager extends EventEmitter
 		.then =>
 			@start(targetService)
 		.then =>
-			@waitToKill(currentService, targetService.config.labels['io.resin.update.handover-timeout'])
+			@waitToKill(currentService, targetService.config.labels['io.balena.update.handover-timeout'])
 		.then =>
 			@kill(currentService)
 

--- a/src/compose/service.ts
+++ b/src/compose/service.ts
@@ -201,13 +201,13 @@ export class Service {
 			service.appId || 0,
 			service.serviceName || '',
 		);
-		config.labels = Service.extendLabels(
+		config.labels = ComposeUtils.normalizeLabels(Service.extendLabels(
 			config.labels || { },
 			options,
 			service.appId || 0,
 			service.serviceId || 0,
 			service.serviceName || '',
-		);
+		));
 
 		// Any other special case handling
 		if (config.networkMode === 'host' && !config.hostname) {
@@ -427,7 +427,7 @@ export class Service {
 			image: container.Config.Image,
 			environment: conversions.envArrayToObject(container.Config.Env || [ ]),
 			privileged: container.HostConfig.Privileged || false,
-			labels: container.Config.Labels || { },
+			labels: ComposeUtils.normalizeLabels(container.Config.Labels || { }),
 			running: container.State.Running,
 			restart,
 			capAdd: container.HostConfig.CapAdd || [ ],
@@ -471,9 +471,9 @@ export class Service {
 			tty: container.Config.Tty || false,
 		};
 
-		svc.appId = checkInt(container.Config.Labels['io.resin.app-id']) || null;
-		svc.serviceId = checkInt(container.Config.Labels['io.resin.service-id']) || null;
-		svc.serviceName = container.Config.Labels['io.resin.service-name'];
+		svc.appId = checkInt(svc.config.labels['io.balena.app-id']) || null;
+		svc.serviceId = checkInt(svc.config.labels['io.balena.service-id']) || null;
+		svc.serviceName = svc.config.labels['io.balena.service-name'];
 		const nameMatch = container.Name.match(/.*_(\d+)_(\d+)$/);
 
 		svc.imageId = nameMatch != null ? checkInt(nameMatch[1]) || null : null;
@@ -788,10 +788,10 @@ export class Service {
 		serviceName: string,
 	): { [labelName: string]: string } {
 		let newLabels = _.defaults(labels, {
-			'io.resin.supervised': 'true',
-			'io.resin.app-id': appId.toString(),
-			'io.resin.service-id': serviceId.toString(),
-			'io.resin.service-name': serviceName,
+			'io.balena.supervised': 'true',
+			'io.balena.app-id': appId.toString(),
+			'io.balena.service-id': serviceId.toString(),
+			'io.balena.service-name': serviceName,
 		});
 
 		const imageLabels = _.get(imageInfo, 'Config.Labels', { });

--- a/src/compose/service.ts
+++ b/src/compose/service.ts
@@ -425,7 +425,10 @@ export class Service {
 			entrypoint: container.Config.Entrypoint || '',
 			volumes: _.concat(container.HostConfig.Binds || [], _.keys(container.Config.Volumes || { })),
 			image: container.Config.Image,
-			environment: conversions.envArrayToObject(container.Config.Env || [ ]),
+			environment: _.omit(conversions.envArrayToObject(container.Config.Env || [ ]), [
+				'RESIN_DEVICE_NAME_AT_INIT',
+				'BALENA_DEVICE_NAME_AT_INIT',
+			]),
 			privileged: container.HostConfig.Privileged || false,
 			labels: ComposeUtils.normalizeLabels(container.Config.Labels || { }),
 			running: container.State.Running,
@@ -483,7 +486,7 @@ export class Service {
 		return svc;
 	}
 
-	public toDockerContainer(): Dockerode.ContainerCreateOptions {
+	public toDockerContainer(opts: { deviceName: string }): Dockerode.ContainerCreateOptions {
 		const { binds, volumes } = this.getBindsAndVolumes();
 		const { exposedPorts, portBindings } = this.generateExposeAndPorts();
 
@@ -503,7 +506,10 @@ export class Service {
 			Volumes: volumes,
 			// Typings are wrong here, the docker daemon accepts a string or string[],
 			Entrypoint: this.config.entrypoint as string,
-			Env: conversions.envObjectToArray(this.config.environment),
+			Env: conversions.envObjectToArray(_.assign({
+				RESIN_DEVICE_NAME_AT_INIT: opts.deviceName,
+				BALENA_DEVICE_NAME_AT_INIT: opts.deviceName,
+			}, this.config.environment)),
 			ExposedPorts: exposedPorts,
 			Image: this.config.image,
 			Labels: this.config.labels,

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -34,7 +34,7 @@ const constants = {
 	imageCleanupErrorIgnoreTimeout: 3600 * 1000,
 	maxDeltaDownloads: 3,
 	defaultVolumeLabels: {
-		'io.resin.supervised': 'true',
+		'io.balena.supervised': 'true',
 	},
 	bootBlockDevice: '/dev/mmcblk0p1',
 	hostConfigVarPrefix: 'RESIN_HOST_',

--- a/test/04-service.spec.coffee
+++ b/test/04-service.spec.coffee
@@ -305,7 +305,7 @@ describe 'compose/service', ->
 					"balena": {
 						"ipv4Address": "1.2.3.4"
 					}
-				}).toDockerContainer().NetworkingConfig).to.deep.equal({
+				}).toDockerContainer({ deviceName: 'foo' }).NetworkingConfig).to.deep.equal({
 					EndpointsConfig: {
 						"123456_balena": {
 							IPAMConfig: {
@@ -323,7 +323,7 @@ describe 'compose/service', ->
 						ipv6Address: '5.6.7.8'
 						linkLocalIps: [ '123.123.123' ]
 					}
-				}).toDockerContainer().NetworkingConfig).to.deep.equal({
+				}).toDockerContainer({ deviceName: 'foo' }).NetworkingConfig).to.deep.equal({
 					EndpointsConfig: {
 						"123456_balena": {
 							IPAMConfig: {

--- a/test/18-compose-network.coffee
+++ b/test/18-compose-network.coffee
@@ -3,7 +3,7 @@ m = require 'mochainon'
 
 { Network } = require '../src/compose/network'
 
-describe 'compose/network.coffee', ->
+describe 'compose/network', ->
 
 	describe 'compose config -> internal config', ->
 
@@ -70,6 +70,6 @@ describe 'compose/network.coffee', ->
 				EnableIPv6: false,
 				Internal: false,
 				Labels: {
-					'io.resin.supervised': 'true'
+					'io.balena.supervised': 'true'
 				}
 			})


### PR DESCRIPTION
But we keep backwards compatibility by normalizing existing io.resin labels
into io.balena ones, and adding both RESIN_ and BALENA_ env vars for these features.

Change-Type: minor
Signed-off-by: Pablo Carranza Velez <pablo@balena.io>