### PR TITLE
Fix preloading in flasher images by reading apps.json if target hasn'…

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -75,6 +75,7 @@ class Config extends EventEmitter {
 		// a JSON value, which is either null, or { app: number, commit: string }
 		pinDevice: { source: 'db', mutable: true, default: 'null' },
 		currentCommit: { source: 'db', mutable: true },
+		targetStateSet: { source: 'db', mutable: true, default: 'false' },
 	};
 
 	public constructor({ db, configPath }: ConfigOpts) {


### PR DESCRIPTION
…t been set

i.e. if we're not provisioned or if the target state is empty (of apps), then we
read apps.json to preload. We then mark that the target state has been set to avoid
trying to preload again if we ever get an empty target state from the API.

Closes #766 

Change-type: patch
Signed-off-by: Pablo Carranza Velez <pablo@balena.io>