### PR TITLE
Update docker-delta to v2.2.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
   },
   "private": "true",
   "dependencies": {
-    "mkfifo": "^0.1.5",
     "sqlite3": "^3.1.0"
   },
   "engines": {
@@ -47,7 +46,7 @@
     "copy-webpack-plugin": "^4.2.3",
     "dbus-native": "^0.2.5",
     "deep-object-diff": "^1.1.0",
-    "docker-delta": "^2.1.0",
+    "docker-delta": "^2.2.2",
     "docker-progress": "^3.0.2",
     "docker-toolbelt": "^3.3.2",
     "duration-js": "^4.0.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -7,7 +7,6 @@ var UglifyPlugin = require("uglifyjs-webpack-plugin");
 const CopyWebpackPlugin = require('copy-webpack-plugin');
 
 var externalModules = [
-	'mkfifo',
 	'sqlite3',
 	'mysql2',
 	'pg',


### PR DESCRIPTION
This fixes occasional timeouts in rsync after applying v2 deltas, which
cause unnecessary fallbacks to a regular pull.

This change also removes the need for the mkfifo native dependency (since
docker-delta 2.2.2 stops using it).

Change-type: patch
Signed-off-by: Pablo Carranza Velez <pablo@balena.io>

(The mkfifo change is a consequence of how the build for the supervisor works: we use webpack, and treat all dependencies as devDependencies except those which have native C extensions, as those are the only ones that are needed besides the minified app.js)