### PR TITLE
test: Use longer delays in logger tests

### DIFF
--- a/test/12-logger.spec.coffee
+++ b/test/12-logger.spec.coffee
@@ -45,7 +45,7 @@ describe 'Logger', ->
 		clock.tick(4999)
 		clock.restore()
 
-		Promise.delay(10)
+		Promise.delay(100)
 		.then =>
 			expect(@_req.body).to.equal('')
 
@@ -55,7 +55,7 @@ describe 'Logger', ->
 		clock.tick(61000)
 		clock.restore()
 
-		Promise.delay(10)
+		Promise.delay(100)
 		.then =>
 			expect(@_req.end.calledOnce).to.be.true
 
@@ -80,7 +80,7 @@ describe 'Logger', ->
 		})
 
 		# small delay for the streams to propagate data
-		Promise.delay(10)
+		Promise.delay(100)
 		.then =>
 			lines = @_req.body.split('\n')
 			expect(lines.length).to.equal(3)
@@ -97,7 +97,7 @@ describe 'Logger', ->
 		clock.tick(10000)
 		clock.restore()
 
-		Promise.delay(10)
+		Promise.delay(100)
 		.then =>
 			expect(@fakeEventTracker.track).to.be.calledWith('Some event name', { someProp: 'someVal' })
 			lines = @_req.body.split('\n')


### PR DESCRIPTION
We've seen at least one case where the 10ms delay
wasn't enough, causing the tests to fail where they shouldn't.

(Ideally we should find a better way to detect when the streams
have finished propagating, but this will avoid failures in the meantime).

Change-type: patch
Signed-off-by: Pablo Carranza Velez <pablo@balena.io>